### PR TITLE
Fix README: PDF report export is free, not paid

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Detect redundant/shadowed rules
 - Severity scoring (HIGH / MEDIUM)
 - Results sorted high → medium, with clickable filters per severity
+- **PDF report export** — download a color-coded findings report at any time
 - Light and dark mode (preference saved automatically)
 - CLI output with audit summary
 
@@ -33,7 +34,6 @@
 - CIS Benchmark compliance checks
 - PCI-DSS compliance checks
 - NIST SP 800-41 compliance checks
-- PDF report export with grouped, color-coded findings
 - Specific control references (e.g. PCI Req 1.3, NIST AC-6)
 
 > 💳 **Purchase a license at [Gumroad](https://shamrock13.gumroad.com/l/flintlock)**
@@ -133,7 +133,13 @@ PYTHONPATH=src python -m flintlock.main --file config.txt --vendor asa
 PYTHONPATH=src python -m flintlock.main --file config.txt --vendor asa --compliance pci
 ```
 
-### Export PDF report
+### Export PDF report (free — no license required)
+
+```bash
+PYTHONPATH=src python -m flintlock.main --file config.txt --vendor asa --report
+```
+
+### Export PDF report with compliance checks (license required)
 
 ```bash
 PYTHONPATH=src python -m flintlock.main --file config.txt --vendor asa --compliance pci --report
@@ -204,6 +210,7 @@ Total Issues:          7
 | Missing deny-all rule | HIGH | Free |
 | Permit rules missing logging | MEDIUM | Free |
 | Redundant/shadowed rules | MEDIUM | Free |
+| PDF report export | — | Free |
 | CIS Benchmark controls | HIGH/MEDIUM | Paid |
 | PCI-DSS requirements | HIGH/MEDIUM | Paid |
 | NIST SP 800-41 controls | HIGH/MEDIUM | Paid |

--- a/src/flintlock/license.py
+++ b/src/flintlock/license.py
@@ -49,7 +49,7 @@ def activate_license(key: str) -> tuple:
 def check_license() -> tuple:
     """Check if a valid license is activated"""
     if not os.path.exists(LICENSE_FILE):
-        return False, "No license found. Purchase a license at gumroad.com/yourpage and activate with --activate YOUR-KEY"
+        return False, "No license found."
 
     try:
         with open(LICENSE_FILE, 'r') as f:
@@ -58,7 +58,7 @@ def check_license() -> tuple:
         if validate_key(key):
             return True, key
         else:
-            return False, "Invalid license key stored. Please reactivate with --activate YOUR-KEY"
+            return False, "Invalid license key. Please re-enter your key to reactivate."
     except Exception as e:
         return False, f"License check failed: {e}"
 

--- a/src/flintlock/main.py
+++ b/src/flintlock/main.py
@@ -93,7 +93,8 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   {message}")
+                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":
@@ -151,7 +152,8 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   {message}")
+                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             from .paloalto import parse_paloalto
@@ -213,7 +215,8 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   {message}")
+                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":
@@ -272,7 +275,8 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   {message}")
+                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":

--- a/src/flintlock/main.py
+++ b/src/flintlock/main.py
@@ -1,4 +1,7 @@
 import typer
+from rich.console import Console
+
+_console = Console()
 
 from .license import activate_license, check_license, deactivate_license
 
@@ -93,7 +96,7 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
                 typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
@@ -152,7 +155,7 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
                 typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
@@ -215,7 +218,7 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
                 typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
@@ -275,7 +278,7 @@ def audit(
             licensed, message = check_license()
             if not licensed:
                 typer.echo(f"\n⚠️  Compliance checks require a valid license.")
-                typer.echo(f"   Purchase a license at: https://shamrock13.gumroad.com/l/flintlock")
+                _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
                 typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")

--- a/src/flintlock/static/style.css
+++ b/src/flintlock/static/style.css
@@ -63,6 +63,9 @@ html { overflow-y: scroll; }
 
 /* ===== Dark Mode ===== */
 [data-theme="dark"] {
+  --header-bg:     #0A1628;
+  --header-border: #152238;
+
   --bg:          #0D0D1A;
   --card-bg:     #12122A;
   --border:      #2A2A4A;

--- a/src/flintlock/static/style.css
+++ b/src/flintlock/static/style.css
@@ -585,6 +585,8 @@ select:focus, input[type="text"]:focus {
 }
 
 .alert-warning { background: var(--alert-warn-bg); border: 1px solid var(--alert-warn-border); color: var(--alert-warn-text); }
+.alert-warning a { color: var(--alert-warn-text); font-weight: 600; }
+.alert-warning a:hover { opacity: 0.8; }
 .alert-error   { background: var(--alert-err-bg);  border: 1px solid var(--alert-err-border);  color: var(--alert-err-text); }
 
 /* ===== License modal internals ===== */

--- a/src/flintlock/templates/index.html
+++ b/src/flintlock/templates/index.html
@@ -287,7 +287,7 @@
       // License warning
       const warn = document.getElementById("licenseWarning");
       if (data.license_warning) {
-        warn.textContent = data.license_warning;
+        warn.innerHTML = data.license_warning;
         warn.classList.remove("hidden");
       } else {
         warn.classList.add("hidden");

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -245,7 +245,11 @@ def run_audit():
         if compliance:
             licensed, lic_msg = check_license()
             if not licensed:
-                license_warning = f"Compliance checks require a valid license. {lic_msg}"
+                license_warning = (
+                    "Compliance checks require a valid license. "
+                    "Purchase one at https://shamrock13.gumroad.com/l/flintlock. "
+                    "Once purchased, enter your key using the Licensed/Unlicensed badge in the top-right corner of the app."
+                )
             else:
                 if vendor == "asa":
                     fn_map = {"cis": check_cis_compliance, "pci": check_pci_compliance, "nist": check_nist_compliance}

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -247,7 +247,7 @@ def run_audit():
             if not licensed:
                 license_warning = (
                     "Compliance checks require a valid license. "
-                    "Purchase one at https://shamrock13.gumroad.com/l/flintlock. "
+                    'Purchase one at <a href="https://shamrock13.gumroad.com/l/flintlock" target="_blank" rel="noopener">shamrock13.gumroad.com/l/flintlock</a>. '
                     "Once purchased, enter your key using the Licensed/Unlicensed badge in the top-right corner of the app."
                 )
             else:


### PR DESCRIPTION
- Move PDF report export to the Free features list
- Remove PDF from the Paid features list
- Add standalone --report CLI example (no license required)
- Clarify --report with --compliance as license-required separately
- Add PDF row to checks table as Free tier