### PR TITLE
Add rule diff, live SSH, AWS/Azure support, Fortinet v2 checks, and archival reviews

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ typer>=0.12
 ciscoconfparse>=1.9
 fpdf2>=2.7
 flask>=3.0
+paramiko>=3.0

--- a/src/flintlock/activity_log.py
+++ b/src/flintlock/activity_log.py
@@ -1,0 +1,77 @@
+"""Activity log — record every user action (audits, SSH attempts, diffs) including failures."""
+import os
+import json
+import uuid
+from datetime import datetime
+
+ACTIVITY_FOLDER = os.environ.get("ACTIVITY_FOLDER", "/tmp/flintlock_activity")
+os.makedirs(ACTIVITY_FOLDER, exist_ok=True)
+
+# Action type constants
+ACTION_FILE_AUDIT   = "file_audit"
+ACTION_SSH_CONNECT  = "ssh_connect"
+ACTION_CONFIG_DIFF  = "config_diff"
+ACTION_COMPARISON   = "archive_compare"
+
+
+def log_activity(action_type: str, label: str, vendor: str | None = None,
+                 success: bool = True, error: str | None = None,
+                 details: dict | None = None) -> str:
+    """
+    Append an activity event.
+
+    Returns the new event ID.
+    """
+    event_id = uuid.uuid4().hex[:12]
+    event = {
+        "id":          event_id,
+        "action":      action_type,
+        "label":       label,
+        "vendor":      vendor or "",
+        "success":     success,
+        "error":       error or "",
+        "details":     details or {},
+        "timestamp":   datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    path = os.path.join(ACTIVITY_FOLDER, f"{event_id}.json")
+    with open(path, "w") as f:
+        json.dump(event, f, indent=2)
+    return event_id
+
+
+def list_activity(limit: int = 200) -> list:
+    """Return activity events sorted newest-first, up to *limit* entries."""
+    events = []
+    for fname in os.listdir(ACTIVITY_FOLDER):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(ACTIVITY_FOLDER, fname)) as f:
+                events.append(json.load(f))
+        except Exception:
+            pass
+    events.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+    return events[:limit]
+
+
+def delete_activity_entry(event_id: str) -> bool:
+    """Delete a single activity log entry. Returns True if deleted."""
+    safe_id = "".join(c for c in event_id if c.isalnum())
+    path = os.path.join(ACTIVITY_FOLDER, f"{safe_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+        return True
+    return False
+
+
+def clear_activity() -> int:
+    """Delete all activity log entries. Returns count deleted."""
+    count = 0
+    for fname in os.listdir(ACTIVITY_FOLDER):
+        if fname.endswith(".json"):
+            try:
+                os.remove(os.path.join(ACTIVITY_FOLDER, fname))
+                count += 1
+            except Exception:
+                pass
+    return count

--- a/src/flintlock/archive.py
+++ b/src/flintlock/archive.py
@@ -1,0 +1,116 @@
+"""Archival review system — persist and compare historical audit results."""
+import os
+import json
+import hashlib
+import uuid
+from datetime import datetime
+
+ARCHIVE_FOLDER = os.environ.get("ARCHIVE_FOLDER", "/tmp/flintlock_archive")
+os.makedirs(ARCHIVE_FOLDER, exist_ok=True)
+
+
+def _fingerprint(filepath):
+    """Return a short SHA-256 fingerprint of a file's content."""
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+def save_audit(filename, vendor, findings, summary, config_path=None):
+    """
+    Save an audit result to the archive.
+    Returns (entry_id, entry_dict).
+    """
+    entry_id = uuid.uuid4().hex[:12]
+    fingerprint = _fingerprint(config_path) if config_path and os.path.exists(config_path) else None
+    entry = {
+        "id":          entry_id,
+        "filename":    filename,
+        "vendor":      vendor,
+        "timestamp":   datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "fingerprint": fingerprint,
+        "summary":     summary,
+        "findings":    findings,
+    }
+    path = os.path.join(ARCHIVE_FOLDER, f"{entry_id}.json")
+    with open(path, "w") as f:
+        json.dump(entry, f, indent=2)
+    return entry_id, entry
+
+
+def list_archive():
+    """Return all archived entries sorted newest-first."""
+    entries = []
+    for fname in os.listdir(ARCHIVE_FOLDER):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(ARCHIVE_FOLDER, fname)) as f:
+                entries.append(json.load(f))
+        except Exception:
+            pass
+    entries.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+    return entries
+
+
+def get_entry(entry_id):
+    """Return a single archive entry by ID, or None."""
+    # Sanitize
+    safe_id = "".join(c for c in entry_id if c.isalnum())
+    path = os.path.join(ARCHIVE_FOLDER, f"{safe_id}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def delete_entry(entry_id):
+    """Delete an archive entry. Returns True if deleted."""
+    safe_id = "".join(c for c in entry_id if c.isalnum())
+    path = os.path.join(ARCHIVE_FOLDER, f"{safe_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+        return True
+    return False
+
+
+# ── Comparison ────────────────────────────────────────────────────────────────
+
+def compare_entries(id_a, id_b):
+    """
+    Compare two archived audits (A = baseline / older, B = current / newer).
+
+    Returns (result_dict, error_str_or_None).
+
+    result keys:
+      entry_a, entry_b       – full entry dicts
+      delta                  – {high, medium, total}  (positive = more issues)
+      new_findings           – issues in B not in A
+      resolved_findings      – issues in A not in B
+      improved               – bool (total delta < 0)
+    """
+    entry_a = get_entry(id_a)
+    entry_b = get_entry(id_b)
+    if not entry_a or not entry_b:
+        return None, "One or both archive entries not found."
+
+    s_a, s_b = entry_a["summary"], entry_b["summary"]
+    set_a = set(entry_a.get("findings", []))
+    set_b = set(entry_b.get("findings", []))
+
+    return {
+        "entry_a":           entry_a,
+        "entry_b":           entry_b,
+        "delta": {
+            "high":   s_b.get("high", 0)   - s_a.get("high", 0),
+            "medium": s_b.get("medium", 0) - s_a.get("medium", 0),
+            "total":  s_b.get("total", 0)  - s_a.get("total", 0),
+        },
+        "new_findings":      sorted(set_b - set_a),
+        "resolved_findings": sorted(set_a - set_b),
+        "improved":          s_b.get("total", 0) < s_a.get("total", 0),
+    }, None

--- a/src/flintlock/aws.py
+++ b/src/flintlock/aws.py
@@ -1,0 +1,151 @@
+"""AWS Security Group parser and auditor."""
+import json
+
+# Ports that should never be open to the world
+SENSITIVE_PORTS = {
+    22:    "SSH",
+    23:    "Telnet",
+    25:    "SMTP",
+    3389:  "RDP",
+    5900:  "VNC",
+    3306:  "MySQL",
+    5432:  "PostgreSQL",
+    1433:  "MSSQL",
+    6379:  "Redis",
+    27017: "MongoDB",
+    11211: "Memcached",
+    9200:  "Elasticsearch",
+}
+
+_ANY_CIDRS = {"0.0.0.0/0", "::/0"}
+
+
+def parse_aws_sg(filepath):
+    """
+    Parse an AWS Security Group JSON file.
+
+    Accepts output from:
+      aws ec2 describe-security-groups
+      (or a single group object / bare list)
+    Returns (list[group_dict], error_str_or_None).
+    """
+    try:
+        with open(filepath, "r") as f:
+            data = json.load(f)
+    except Exception as e:
+        return None, f"Failed to parse AWS Security Group JSON: {e}"
+
+    if isinstance(data, dict) and "SecurityGroups" in data:
+        groups = data["SecurityGroups"]
+    elif isinstance(data, list):
+        groups = data
+    elif isinstance(data, dict) and "GroupId" in data:
+        groups = [data]
+    else:
+        return None, "Unrecognized AWS Security Group JSON format. Expected SecurityGroups key or a group/list."
+
+    return groups, None
+
+
+def _is_any(cidr):
+    return cidr in _ANY_CIDRS
+
+
+def _all_cidrs(rule):
+    """Yield all CIDR strings referenced in a rule (IPv4 + IPv6)."""
+    for r in rule.get("IpRanges", []):
+        yield r.get("CidrIp", ""), r.get("Description", ""), "ipv4"
+    for r in rule.get("Ipv6Ranges", []):
+        yield r.get("CidrIpv6", ""), r.get("Description", ""), "ipv6"
+
+
+def check_wide_open_ingress(groups):
+    findings = []
+    for sg in groups:
+        sg_id   = sg.get("GroupId", "unknown")
+        sg_name = sg.get("GroupName", "unnamed")
+        for rule in sg.get("IpPermissions", []):
+            proto     = rule.get("IpProtocol", "")
+            from_port = rule.get("FromPort", -1)
+            to_port   = rule.get("ToPort", -1)
+            for cidr, _desc, _ver in _all_cidrs(rule):
+                if not _is_any(cidr):
+                    continue
+                tag = f"Security Group '{sg_name}' ({sg_id})"
+                if proto == "-1":
+                    findings.append(
+                        f"[HIGH] {tag}: ALL traffic allowed inbound from {cidr}"
+                    )
+                elif from_port in SENSITIVE_PORTS:
+                    svc = SENSITIVE_PORTS[from_port]
+                    findings.append(
+                        f"[HIGH] {tag}: {svc} (port {from_port}) open to {cidr}"
+                    )
+                elif from_port == 0 and to_port == 65535:
+                    findings.append(
+                        f"[HIGH] {tag}: All ports open inbound from {cidr} (proto {proto})"
+                    )
+                else:
+                    port_str = f"{from_port}" if from_port == to_port else f"{from_port}-{to_port}"
+                    findings.append(
+                        f"[MEDIUM] {tag}: Port {port_str} ({proto}) open to {cidr}"
+                    )
+    return findings
+
+
+def check_wide_open_egress(groups):
+    findings = []
+    for sg in groups:
+        sg_id   = sg.get("GroupId", "unknown")
+        sg_name = sg.get("GroupName", "unnamed")
+        flagged = False
+        for rule in sg.get("IpPermissionsEgress", []):
+            if flagged:
+                break
+            proto = rule.get("IpProtocol", "")
+            for cidr, _desc, _ver in _all_cidrs(rule):
+                if _is_any(cidr) and proto == "-1":
+                    findings.append(
+                        f"[MEDIUM] Security Group '{sg_name}' ({sg_id}): "
+                        f"Unrestricted outbound traffic to {cidr} — consider restricting egress"
+                    )
+                    flagged = True
+                    break
+    return findings
+
+
+def check_missing_descriptions(groups):
+    findings = []
+    for sg in groups:
+        sg_id   = sg.get("GroupId", "unknown")
+        sg_name = sg.get("GroupName", "unnamed")
+        desc = (sg.get("Description") or "").strip().lower()
+        if not desc or desc in ("launch-wizard", "default", ""):
+            findings.append(
+                f"[MEDIUM] Security Group '{sg_name}' ({sg_id}): Missing or generic group description"
+            )
+        # Flag individual rules with no description
+        for rule in sg.get("IpPermissions", []):
+            from_port = rule.get("FromPort", -1)
+            to_port   = rule.get("ToPort", -1)
+            for ip_range in rule.get("IpRanges", []):
+                if not ip_range.get("Description", "").strip():
+                    port_str = f"{from_port}" if from_port == to_port else f"{from_port}-{to_port}"
+                    findings.append(
+                        f"[MEDIUM] Security Group '{sg_name}' ({sg_id}): "
+                        f"Inbound rule port {port_str} has no description"
+                    )
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(findings))
+
+
+def audit_aws_sg(filepath):
+    """Run all checks. Returns (findings_list, groups_list)."""
+    groups, error = parse_aws_sg(filepath)
+    if error:
+        return [f"[ERROR] {error}"], []
+    findings = []
+    findings += check_wide_open_ingress(groups)
+    findings += check_wide_open_egress(groups)
+    findings += check_missing_descriptions(groups)
+    return findings, groups

--- a/src/flintlock/azure.py
+++ b/src/flintlock/azure.py
@@ -1,0 +1,150 @@
+"""Azure Network Security Group (NSG) parser and auditor."""
+import json
+
+SENSITIVE_PORTS = {
+    "22":    "SSH",
+    "23":    "Telnet",
+    "25":    "SMTP",
+    "3389":  "RDP",
+    "5900":  "VNC",
+    "3306":  "MySQL",
+    "5432":  "PostgreSQL",
+    "1433":  "MSSQL",
+    "6379":  "Redis",
+    "27017": "MongoDB",
+}
+
+_ANY_SOURCES = {"*", "Internet", "Any", "0.0.0.0/0", "::/0"}
+
+
+def parse_azure_nsg(filepath):
+    """
+    Parse an Azure NSG JSON file.
+
+    Accepts output from:
+      az network nsg show / az network nsg list
+      (single NSG object, array, or {value: [...]} wrapper)
+    Returns (list[nsg_dict], error_str_or_None).
+    """
+    try:
+        with open(filepath, "r") as f:
+            data = json.load(f)
+    except Exception as e:
+        return None, f"Failed to parse Azure NSG JSON: {e}"
+
+    if isinstance(data, list):
+        nsgs = data
+    elif isinstance(data, dict):
+        if "value" in data:
+            nsgs = data["value"]
+        elif "name" in data or "securityRules" in data:
+            nsgs = [data]
+        else:
+            return None, "Unrecognized Azure NSG JSON format."
+    else:
+        return None, "Unrecognized Azure NSG JSON format."
+
+    return nsgs, None
+
+
+def _props(rule):
+    """Return the properties dict, handling both flat and nested ('properties') formats."""
+    return rule.get("properties", rule)
+
+
+def _port_ranges(rule_props):
+    """Return a flat list of destination port range strings."""
+    single = rule_props.get("destinationPortRange", "")
+    multi  = rule_props.get("destinationPortRanges", [])
+    ports  = list(multi) if multi else []
+    if single:
+        ports.append(single)
+    return ports
+
+
+def check_inbound_any(nsgs):
+    findings = []
+    for nsg in nsgs:
+        nsg_name = nsg.get("name", "unnamed")
+        rules = nsg.get("securityRules", []) + nsg.get("defaultSecurityRules", [])
+        for rule in rules:
+            props     = _props(rule)
+            direction = props.get("direction", "")
+            access    = props.get("access", "")
+            src       = props.get("sourceAddressPrefix", "")
+            rule_name = rule.get("name", "unnamed")
+            priority  = props.get("priority", "?")
+
+            if direction != "Inbound" or access != "Allow":
+                continue
+            if src not in _ANY_SOURCES:
+                continue
+
+            ports = _port_ranges(props)
+            if not ports or "*" in ports:
+                findings.append(
+                    f"[HIGH] NSG '{nsg_name}' rule '{rule_name}' (priority {priority}): "
+                    f"ALL inbound traffic from Any source allowed"
+                )
+            else:
+                for port in ports:
+                    if port in SENSITIVE_PORTS:
+                        svc = SENSITIVE_PORTS[port]
+                        findings.append(
+                            f"[HIGH] NSG '{nsg_name}' rule '{rule_name}' (priority {priority}): "
+                            f"{svc} port {port} open to Any source"
+                        )
+                    else:
+                        findings.append(
+                            f"[MEDIUM] NSG '{nsg_name}' rule '{rule_name}' (priority {priority}): "
+                            f"Port {port} open to Any source"
+                        )
+    return findings
+
+
+def check_missing_flow_logs(nsgs):
+    """Flag NSGs where flow log status cannot be confirmed from the JSON."""
+    findings = []
+    for nsg in nsgs:
+        nsg_name = nsg.get("name", "unnamed")
+        if "flowLogs" not in nsg and "diagnosticSettings" not in nsg:
+            findings.append(
+                f"[MEDIUM] NSG '{nsg_name}': Flow log status unknown — "
+                f"verify NSG flow logs are enabled (az network watcher flow-log show)"
+            )
+    return findings
+
+
+def check_high_priority_allow_all(nsgs):
+    """Flag any high-priority (low priority number) Allow-All inbound rules."""
+    findings = []
+    for nsg in nsgs:
+        nsg_name = nsg.get("name", "unnamed")
+        for rule in nsg.get("securityRules", []):
+            props    = _props(rule)
+            priority = props.get("priority", 9999)
+            if (
+                props.get("direction") == "Inbound"
+                and props.get("access") == "Allow"
+                and props.get("sourceAddressPrefix") in _ANY_SOURCES
+                and ("*" in _port_ranges(props) or not _port_ranges(props))
+                and int(priority) < 500
+            ):
+                rule_name = rule.get("name", "unnamed")
+                findings.append(
+                    f"[HIGH] NSG '{nsg_name}' rule '{rule_name}' (priority {priority}): "
+                    f"High-priority allow-all inbound rule may override downstream security rules"
+                )
+    return findings
+
+
+def audit_azure_nsg(filepath):
+    """Run all checks. Returns (findings_list, nsgs_list)."""
+    nsgs, error = parse_azure_nsg(filepath)
+    if error:
+        return [f"[ERROR] {error}"], []
+    findings = []
+    findings += check_inbound_any(nsgs)
+    findings += check_missing_flow_logs(nsgs)
+    findings += check_high_priority_allow_all(nsgs)
+    return findings, nsgs

--- a/src/flintlock/diff.py
+++ b/src/flintlock/diff.py
@@ -1,0 +1,122 @@
+"""Rule diff engine — compare two firewall configs of the same vendor."""
+import re
+from ciscoconfparse import CiscoConfParse
+from .paloalto import parse_paloalto
+from .fortinet import parse_fortinet
+from .pfsense import parse_pfsense
+
+
+# ── ASA ──────────────────────────────────────────────────────────────────────
+
+def _sig_asa(text):
+    """Normalise a Cisco access-list line for comparison (strip log variants)."""
+    t = text.strip().lower()
+    t = re.sub(r'\s+log\b.*', '', t)
+    return re.sub(r'\s+', ' ', t).strip()
+
+
+def diff_asa(path_a, path_b):
+    pa = CiscoConfParse(path_a, ignore_blank_lines=False)
+    pb = CiscoConfParse(path_b, ignore_blank_lines=False)
+    rules_a = {_sig_asa(r.text): r.text for r in pa.find_objects(r"access-list")}
+    rules_b = {_sig_asa(r.text): r.text for r in pb.find_objects(r"access-list")}
+    added     = [rules_b[s] for s in rules_b if s not in rules_a]
+    removed   = [rules_a[s] for s in rules_a if s not in rules_b]
+    unchanged = [rules_a[s] for s in rules_a if s in rules_b]
+    return {"added": added, "removed": removed, "unchanged": unchanged}
+
+
+# ── Fortinet ─────────────────────────────────────────────────────────────────
+
+def _sig_forti(policy):
+    return (
+        tuple(sorted(policy.get("srcaddr", []))),
+        tuple(sorted(policy.get("dstaddr", []))),
+        tuple(sorted(policy.get("service", []))),
+        policy.get("action", ""),
+    )
+
+
+def _fmt_forti(p):
+    name = p.get("name") or f"Policy {p.get('id')}"
+    src  = ",".join(p.get("srcaddr", []))
+    dst  = ",".join(p.get("dstaddr", []))
+    return f"{name}: {src} → {dst} ({p.get('action', '')})"
+
+
+def diff_fortinet(path_a, path_b):
+    pols_a, _ = parse_fortinet(path_a)
+    pols_b, _ = parse_fortinet(path_b)
+    sig_a = {_sig_forti(p): p for p in (pols_a or [])}
+    sig_b = {_sig_forti(p): p for p in (pols_b or [])}
+    added     = [_fmt_forti(sig_b[s]) for s in sig_b if s not in sig_a]
+    removed   = [_fmt_forti(sig_a[s]) for s in sig_a if s not in sig_b]
+    unchanged = [_fmt_forti(sig_a[s]) for s in sig_a if s in sig_b]
+    return {"added": added, "removed": removed, "unchanged": unchanged}
+
+
+# ── Palo Alto ─────────────────────────────────────────────────────────────────
+
+def _sig_pa(rule):
+    return (
+        tuple(sorted(s.text for s in rule.findall(".//source/member"))),
+        tuple(sorted(d.text for d in rule.findall(".//destination/member"))),
+        tuple(sorted(a.text for a in rule.findall(".//application/member"))),
+        tuple(sorted(s.text for s in rule.findall(".//service/member"))),
+        rule.findtext(".//action"),
+    )
+
+
+def _fmt_pa(rule):
+    name   = rule.get("name", "unnamed")
+    src    = ",".join(s.text for s in rule.findall(".//source/member"))
+    dst    = ",".join(d.text for d in rule.findall(".//destination/member"))
+    action = rule.findtext(".//action") or ""
+    return f"{name}: {src} → {dst} ({action})"
+
+
+def diff_paloalto(path_a, path_b):
+    rules_a, _ = parse_paloalto(path_a)
+    rules_b, _ = parse_paloalto(path_b)
+    sig_a = {_sig_pa(r): r for r in (rules_a or [])}
+    sig_b = {_sig_pa(r): r for r in (rules_b or [])}
+    added     = [_fmt_pa(sig_b[s]) for s in sig_b if s not in sig_a]
+    removed   = [_fmt_pa(sig_a[s]) for s in sig_a if s not in sig_b]
+    unchanged = [_fmt_pa(sig_a[s]) for s in sig_a if s in sig_b]
+    return {"added": added, "removed": removed, "unchanged": unchanged}
+
+
+# ── pfSense ───────────────────────────────────────────────────────────────────
+
+def _sig_pf(rule):
+    return (rule["type"], rule["source"], rule["destination"], rule["protocol"])
+
+
+def _fmt_pf(r):
+    return f"{r['descr']}: {r['source']} → {r['destination']} ({r['type']}/{r['protocol']})"
+
+
+def diff_pfsense(path_a, path_b):
+    rules_a, _ = parse_pfsense(path_a)
+    rules_b, _ = parse_pfsense(path_b)
+    sig_a = {_sig_pf(r): r for r in (rules_a or [])}
+    sig_b = {_sig_pf(r): r for r in (rules_b or [])}
+    added     = [_fmt_pf(sig_b[s]) for s in sig_b if s not in sig_a]
+    removed   = [_fmt_pf(sig_a[s]) for s in sig_a if s not in sig_b]
+    unchanged = [_fmt_pf(sig_a[s]) for s in sig_a if s in sig_b]
+    return {"added": added, "removed": removed, "unchanged": unchanged}
+
+
+# ── Main entrypoint ───────────────────────────────────────────────────────────
+
+def diff_configs(vendor, path_a, path_b):
+    """Compare two configs of the same vendor. Returns {added, removed, unchanged}."""
+    if vendor == "asa":
+        return diff_asa(path_a, path_b)
+    if vendor == "fortinet":
+        return diff_fortinet(path_a, path_b)
+    if vendor == "paloalto":
+        return diff_paloalto(path_a, path_b)
+    if vendor == "pfsense":
+        return diff_pfsense(path_a, path_b)
+    raise ValueError(f"Unsupported vendor for diff: {vendor}")

--- a/src/flintlock/diff.py
+++ b/src/flintlock/diff.py
@@ -24,15 +24,15 @@ def diff_asa(path_a, path_b):
 
     # Use Counter so duplicate rules (e.g. same rule with and without 'log') are
     # counted separately rather than collapsed into one dict entry.
-    cnt_a  = Counter(_sig_asa(l) for l in lines_a)
-    cnt_b  = Counter(_sig_asa(l) for l in lines_b)
+    cnt_a  = Counter(_sig_asa(line) for line in lines_a)
+    cnt_b  = Counter(_sig_asa(line) for line in lines_b)
     # Keep first-seen display text for each signature
     text_a = {}
-    for l in lines_a:
-        text_a.setdefault(_sig_asa(l), l)
+    for line in lines_a:
+        text_a.setdefault(_sig_asa(line), line)
     text_b = {}
-    for l in lines_b:
-        text_b.setdefault(_sig_asa(l), l)
+    for line in lines_b:
+        text_b.setdefault(_sig_asa(line), line)
 
     added, removed, unchanged = [], [], []
     for sig in set(cnt_a) | set(cnt_b):

--- a/src/flintlock/diff.py
+++ b/src/flintlock/diff.py
@@ -1,5 +1,6 @@
 """Rule diff engine — compare two firewall configs of the same vendor."""
 import re
+from collections import Counter
 from ciscoconfparse import CiscoConfParse
 from .paloalto import parse_paloalto
 from .fortinet import parse_fortinet
@@ -18,11 +19,34 @@ def _sig_asa(text):
 def diff_asa(path_a, path_b):
     pa = CiscoConfParse(path_a, ignore_blank_lines=False)
     pb = CiscoConfParse(path_b, ignore_blank_lines=False)
-    rules_a = {_sig_asa(r.text): r.text for r in pa.find_objects(r"access-list")}
-    rules_b = {_sig_asa(r.text): r.text for r in pb.find_objects(r"access-list")}
-    added     = [rules_b[s] for s in rules_b if s not in rules_a]
-    removed   = [rules_a[s] for s in rules_a if s not in rules_b]
-    unchanged = [rules_a[s] for s in rules_a if s in rules_b]
+    lines_a = [r.text for r in pa.find_objects(r"access-list")]
+    lines_b = [r.text for r in pb.find_objects(r"access-list")]
+
+    # Use Counter so duplicate rules (e.g. same rule with and without 'log') are
+    # counted separately rather than collapsed into one dict entry.
+    cnt_a  = Counter(_sig_asa(l) for l in lines_a)
+    cnt_b  = Counter(_sig_asa(l) for l in lines_b)
+    # Keep first-seen display text for each signature
+    text_a = {}
+    for l in lines_a:
+        text_a.setdefault(_sig_asa(l), l)
+    text_b = {}
+    for l in lines_b:
+        text_b.setdefault(_sig_asa(l), l)
+
+    added, removed, unchanged = [], [], []
+    for sig in set(cnt_a) | set(cnt_b):
+        a, b    = cnt_a[sig], cnt_b[sig]
+        keep    = min(a, b)
+        extra_a = a - keep
+        extra_b = b - keep
+        for _ in range(keep):
+            unchanged.append(text_a.get(sig, text_b.get(sig)))
+        for _ in range(extra_a):
+            removed.append(text_a[sig])
+        for _ in range(extra_b):
+            added.append(text_b[sig])
+
     return {"added": added, "removed": removed, "unchanged": unchanged}
 
 

--- a/src/flintlock/fortinet.py
+++ b/src/flintlock/fortinet.py
@@ -1,4 +1,3 @@
-import re
 
 # Services considered insecure if allowed to broad destinations
 _INSECURE_SERVICES = {"TELNET", "HTTP", "FTP", "TFTP", "SNMP"}

--- a/src/flintlock/fortinet.py
+++ b/src/flintlock/fortinet.py
@@ -1,8 +1,11 @@
 import re
 
+# Services considered insecure if allowed to broad destinations
+_INSECURE_SERVICES = {"TELNET", "HTTP", "FTP", "TFTP", "SNMP"}
+
 
 def parse_fortinet(filepath):
-    """Parse a FortiGate config and return firewall policies"""
+    """Parse a FortiGate config and return firewall policies."""
     try:
         with open(filepath, 'r') as f:
             content = f.read()
@@ -16,12 +19,26 @@ def parse_fortinet(filepath):
         line = line.strip()
 
         if line.startswith("edit "):
-            current_policy = {"id": line.split("edit ")[1], "srcaddr": [], "dstaddr": [], 
-                            "service": [], "action": "", "logtraffic": "", "name": ""}
+            current_policy = {
+                "id":         line.split("edit ")[1],
+                "name":       "",
+                "srcintf":    [],
+                "dstintf":    [],
+                "srcaddr":    [],
+                "dstaddr":    [],
+                "service":    [],
+                "action":     "",
+                "logtraffic": "",
+                "status":     "enable",   # default is enabled
+            }
 
         elif current_policy is not None:
             if line.startswith("set name "):
                 current_policy["name"] = line.split("set name ")[1].strip('"')
+            elif line.startswith("set srcintf "):
+                current_policy["srcintf"] = [x.strip('"') for x in line.replace("set srcintf ", "").strip().split()]
+            elif line.startswith("set dstintf "):
+                current_policy["dstintf"] = [x.strip('"') for x in line.replace("set dstintf ", "").strip().split()]
             elif line.startswith("set srcaddr "):
                 current_policy["srcaddr"] = [x.strip('"') for x in line.replace("set srcaddr ", "").strip().split()]
             elif line.startswith("set dstaddr "):
@@ -32,6 +49,8 @@ def parse_fortinet(filepath):
                 current_policy["action"] = line.split("set action ")[1].strip().strip('"')
             elif line.startswith("set logtraffic "):
                 current_policy["logtraffic"] = line.split("set logtraffic ")[1].strip().strip('"')
+            elif line.startswith("set status "):
+                current_policy["status"] = line.split("set status ")[1].strip().strip('"')
             elif line == "next":
                 policies.append(current_policy)
                 current_policy = None
@@ -39,14 +58,17 @@ def parse_fortinet(filepath):
     return policies, None
 
 
+# ── Core checks (v1) ─────────────────────────────────────────────────────────
+
 def check_any_any_forti(policies):
     findings = []
     for p in policies:
-        name = p.get("name") or f"Policy ID {p.get('id')}"
-        src = p.get("srcaddr", [])
-        dst = p.get("dstaddr", [])
+        if p.get("status") == "disable":
+            continue
+        name   = p.get("name") or f"Policy ID {p.get('id')}"
+        src    = p.get("srcaddr", [])
+        dst    = p.get("dstaddr", [])
         action = p.get("action", "")
-
         if action == "accept" and "all" in src and "all" in dst:
             findings.append(f"[HIGH] Overly permissive rule '{name}': source=all destination=all")
     return findings
@@ -55,60 +77,122 @@ def check_any_any_forti(policies):
 def check_missing_logging_forti(policies):
     findings = []
     for p in policies:
-        name = p.get("name") or f"Policy ID {p.get('id')}"
-        action = p.get("action", "")
-        logtraffic = p.get("logtraffic", "")
-
+        if p.get("status") == "disable":
+            continue
+        name      = p.get("name") or f"Policy ID {p.get('id')}"
+        action    = p.get("action", "")
+        logtraffic= p.get("logtraffic", "")
         if action == "accept" and logtraffic not in ["all", "utm"]:
             findings.append(f"[MEDIUM] Permit rule '{name}' missing logging")
     return findings
 
 
 def check_deny_all_forti(policies):
-    findings = []
-    has_deny_all = False
-
-    for p in policies:
-        src = p.get("srcaddr", [])
-        dst = p.get("dstaddr", [])
-        action = p.get("action", "")
-
-        if action == "deny" and "all" in src and "all" in dst:
-            has_deny_all = True
-            break
-
-    if not has_deny_all:
-        findings.append("[HIGH] No explicit deny-all rule found")
-    return findings
+    has_deny_all = any(
+        p.get("action") == "deny" and "all" in p.get("srcaddr", []) and "all" in p.get("dstaddr", [])
+        for p in policies
+    )
+    return [] if has_deny_all else ["[HIGH] No explicit deny-all rule found"]
 
 
 def check_redundant_rules_forti(policies):
     findings = []
     seen = []
-
     for p in policies:
         name = p.get("name") or f"Policy ID {p.get('id')}"
-        src = tuple(sorted(p.get("srcaddr", [])))
-        dst = tuple(sorted(p.get("dstaddr", [])))
-        svc = tuple(sorted(p.get("service", [])))
-        action = p.get("action", "")
-
-        signature = (src, dst, svc, action)
-        if signature in seen:
+        sig  = (
+            tuple(sorted(p.get("srcaddr", []))),
+            tuple(sorted(p.get("dstaddr", []))),
+            tuple(sorted(p.get("service", []))),
+            p.get("action", ""),
+        )
+        if sig in seen:
             findings.append(f"[MEDIUM] Redundant rule detected: '{name}'")
         else:
-            seen.append(signature)
+            seen.append(sig)
     return findings
 
+
+# ── v2 enhanced checks ────────────────────────────────────────────────────────
+
+def check_disabled_policies_forti(policies):
+    """Flag disabled policies — they add confusion and should be removed if unused."""
+    findings = []
+    for p in policies:
+        if p.get("status") == "disable":
+            name = p.get("name") or f"Policy ID {p.get('id')}"
+            findings.append(
+                f"[MEDIUM] Policy '{name}' is disabled — "
+                f"review and remove if no longer needed"
+            )
+    return findings
+
+
+def check_any_service_forti(policies):
+    """Flag accept policies that allow ALL services (service=ALL)."""
+    findings = []
+    for p in policies:
+        if p.get("status") == "disable":
+            continue
+        name    = p.get("name") or f"Policy ID {p.get('id')}"
+        action  = p.get("action", "")
+        service = p.get("service", [])
+        if action == "accept" and "ALL" in [s.upper() for s in service]:
+            src = ",".join(p.get("srcaddr", []))
+            dst = ",".join(p.get("dstaddr", []))
+            findings.append(
+                f"[HIGH] Policy '{name}' allows ALL services: {src} → {dst} — "
+                f"restrict to required services only"
+            )
+    return findings
+
+
+def check_insecure_services_forti(policies):
+    """Flag accept policies that allow known-insecure services (Telnet, HTTP, FTP, TFTP, SNMP)."""
+    findings = []
+    for p in policies:
+        if p.get("status") == "disable":
+            continue
+        name    = p.get("name") or f"Policy ID {p.get('id')}"
+        action  = p.get("action", "")
+        service = {s.upper() for s in p.get("service", [])}
+        bad     = service & _INSECURE_SERVICES
+        if action == "accept" and bad:
+            findings.append(
+                f"[MEDIUM] Policy '{name}' allows insecure service(s): "
+                f"{', '.join(sorted(bad))} — use encrypted alternatives"
+            )
+    return findings
+
+
+def check_missing_names_forti(policies):
+    """Flag policies with no human-readable name set."""
+    findings = []
+    for p in policies:
+        if not p.get("name"):
+            findings.append(
+                f"[MEDIUM] Policy ID {p.get('id')} has no name set — "
+                f"add a descriptive name for auditability"
+            )
+    return findings
+
+
+# ── Audit entrypoint ─────────────────────────────────────────────────────────
 
 def audit_fortinet(filepath):
     policies, error = parse_fortinet(filepath)
     if error:
-        return [f"[ERROR] {error}"]
+        return [f"[ERROR] {error}"], []
 
     findings = []
+    # v1 core checks
     findings += check_any_any_forti(policies)
     findings += check_missing_logging_forti(policies)
     findings += check_deny_all_forti(policies)
     findings += check_redundant_rules_forti(policies)
+    # v2 enhanced checks
+    findings += check_disabled_policies_forti(policies)
+    findings += check_any_service_forti(policies)
+    findings += check_insecure_services_forti(policies)
+    findings += check_missing_names_forti(policies)
     return findings, policies

--- a/src/flintlock/main.py
+++ b/src/flintlock/main.py
@@ -1,22 +1,14 @@
 import typer
 from rich.console import Console
-
-_console = Console()
-
 from .license import activate_license, check_license, deactivate_license
-
 from .compliance import check_cis_compliance, check_pci_compliance, check_nist_compliance
-
+from .paloalto import audit_paloalto
+from .reporter import generate_report
+from .fortinet import audit_fortinet
+from .pfsense import audit_pfsense
 from ciscoconfparse import CiscoConfParse
 
-from .paloalto import audit_paloalto
-
-from .reporter import generate_report
-
-from .fortinet import audit_fortinet
-
-from .pfsense import audit_pfsense
-
+_console = Console()
 app = typer.Typer()
 
 def check_any_any(parse):
@@ -95,9 +87,9 @@ def audit(
         if compliance:
             licensed, message = check_license()
             if not licensed:
-                typer.echo(f"\n⚠️  Compliance checks require a valid license.")
+                typer.echo("\n⚠️  Compliance checks require a valid license.")
                 _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
-                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
+                typer.echo("   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":
@@ -127,7 +119,7 @@ def audit(
         nist_high = [f for f in findings if "NIST-HIGH" in f]
         nist_medium = [f for f in findings if "NIST-MEDIUM" in f]
 
-        typer.echo(f"\n--- Audit Summary ---")
+        typer.echo("\n--- Audit Summary ---")
         typer.echo(f"High Severity:         {len(high)}")
         typer.echo(f"Medium Severity:       {len(medium)}")
         if pci_high or pci_medium:
@@ -140,7 +132,7 @@ def audit(
             typer.echo(f"NIST Compliance High:  {len(nist_high)}")
             typer.echo(f"NIST Compliance Medium:{len(nist_medium)}")
         typer.echo(f"Total Issues:          {len(findings)}")
-        typer.echo(f"---------------------")
+        typer.echo("---------------------")
     
     elif vendor == "paloalto":
         findings = audit_paloalto(file)
@@ -154,9 +146,9 @@ def audit(
         if compliance:
             licensed, message = check_license()
             if not licensed:
-                typer.echo(f"\n⚠️  Compliance checks require a valid license.")
+                typer.echo("\n⚠️  Compliance checks require a valid license.")
                 _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
-                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
+                typer.echo("   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             from .paloalto import parse_paloalto
@@ -188,7 +180,7 @@ def audit(
         nist_high = [f for f in findings if "NIST-HIGH" in f]
         nist_medium = [f for f in findings if "NIST-MEDIUM" in f]
 
-        typer.echo(f"\n--- Audit Summary ---")
+        typer.echo("\n--- Audit Summary ---")
         typer.echo(f"High Severity:         {len(high)}")
         typer.echo(f"Medium Severity:       {len(medium)}")
         if pci_high or pci_medium:
@@ -201,7 +193,7 @@ def audit(
             typer.echo(f"NIST Compliance High:  {len(nist_high)}")
             typer.echo(f"NIST Compliance Medium:{len(nist_medium)}")
         typer.echo(f"Total Issues:          {len(findings)}")
-        typer.echo(f"---------------------")
+        typer.echo("---------------------")
 
     elif vendor == "fortinet":
         from .compliance import check_cis_compliance_forti, check_pci_compliance_forti, check_nist_compliance_forti
@@ -217,9 +209,9 @@ def audit(
         if compliance:
             licensed, message = check_license()
             if not licensed:
-                typer.echo(f"\n⚠️  Compliance checks require a valid license.")
+                typer.echo("\n⚠️  Compliance checks require a valid license.")
                 _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
-                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
+                typer.echo("   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":
@@ -248,7 +240,7 @@ def audit(
         nist_high = [f for f in findings if "NIST-HIGH" in f]
         nist_medium = [f for f in findings if "NIST-MEDIUM" in f]
 
-        typer.echo(f"\n--- Audit Summary ---")
+        typer.echo("\n--- Audit Summary ---")
         typer.echo(f"High Severity:         {len(high)}")
         typer.echo(f"Medium Severity:       {len(medium)}")
         if pci_high or pci_medium:
@@ -261,7 +253,7 @@ def audit(
             typer.echo(f"NIST Compliance High:  {len(nist_high)}")
             typer.echo(f"NIST Compliance Medium:{len(nist_medium)}")
         typer.echo(f"Total Issues:          {len(findings)}")
-        typer.echo(f"---------------------")
+        typer.echo("---------------------")
 
     elif vendor == "pfsense":
         from .compliance import check_cis_compliance_pf, check_pci_compliance_pf, check_nist_compliance_pf
@@ -277,9 +269,9 @@ def audit(
         if compliance:
             licensed, message = check_license()
             if not licensed:
-                typer.echo(f"\n⚠️  Compliance checks require a valid license.")
+                typer.echo("\n⚠️  Compliance checks require a valid license.")
                 _console.print("   Purchase a license at: [link=https://shamrock13.gumroad.com/l/flintlock]https://shamrock13.gumroad.com/l/flintlock[/link]")
-                typer.echo(f"   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
+                typer.echo("   Once purchased, activate your key: flintlock --activate YOUR-LICENSE-KEY")
                 raise typer.Exit()
             typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")
             if compliance == "cis":
@@ -308,7 +300,7 @@ def audit(
         nist_high = [f for f in findings if "NIST-HIGH" in f]
         nist_medium = [f for f in findings if "NIST-MEDIUM" in f]
 
-        typer.echo(f"\n--- Audit Summary ---")
+        typer.echo("\n--- Audit Summary ---")
         typer.echo(f"High Severity:         {len(high)}")
         typer.echo(f"Medium Severity:       {len(medium)}")
         if pci_high or pci_medium:
@@ -321,7 +313,7 @@ def audit(
             typer.echo(f"NIST Compliance High:  {len(nist_high)}")
             typer.echo(f"NIST Compliance Medium:{len(nist_medium)}")
         typer.echo(f"Total Issues:          {len(findings)}")
-        typer.echo(f"---------------------")
+        typer.echo("---------------------")
 
 if __name__ == "__main__":
     app()

--- a/src/flintlock/ssh_connector.py
+++ b/src/flintlock/ssh_connector.py
@@ -1,0 +1,144 @@
+"""Live SSH connector — pull running configs from network devices."""
+import os
+import time
+import uuid
+import tempfile
+
+try:
+    import paramiko
+    PARAMIKO_AVAILABLE = True
+except ImportError:
+    PARAMIKO_AVAILABLE = False
+
+RECV_TIMEOUT = 30    # seconds to wait for device output
+RECV_CHUNK   = 65536
+
+
+def _require_paramiko():
+    if not PARAMIKO_AVAILABLE:
+        raise RuntimeError(
+            "Live SSH connection requires the 'paramiko' library. "
+            "Install it with: pip install paramiko"
+        )
+
+
+def _read_until_idle(channel, timeout=RECV_TIMEOUT, idle_secs=1.5):
+    """Read from channel until no data arrives for idle_secs, or timeout expires."""
+    output = b""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if channel.recv_ready():
+            chunk = channel.recv(RECV_CHUNK)
+            if not chunk:
+                break
+            output += chunk
+        else:
+            time.sleep(0.3)
+            # If no data for idle_secs consecutively, assume done
+            if not channel.recv_ready():
+                time.sleep(idle_secs)
+                if not channel.recv_ready():
+                    break
+    return output.decode("utf-8", errors="ignore")
+
+
+def _make_client(host, port, username, password, timeout):
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        host, port=port, username=username, password=password,
+        timeout=timeout, look_for_keys=False, allow_agent=False,
+    )
+    return client
+
+
+# ── Cisco ASA ─────────────────────────────────────────────────────────────────
+
+def _pull_asa(host, port, username, password, timeout):
+    _require_paramiko()
+    client = _make_client(host, port, username, password, timeout)
+    try:
+        ch = client.invoke_shell()
+        time.sleep(1)
+        ch.recv(RECV_CHUNK)  # flush banner
+        ch.send("terminal pager 0\n")
+        time.sleep(0.5)
+        ch.recv(RECV_CHUNK)
+        ch.send("show running-config\n")
+        return _read_until_idle(ch)
+    finally:
+        client.close()
+
+
+# ── Fortinet ──────────────────────────────────────────────────────────────────
+
+def _pull_fortinet(host, port, username, password, timeout):
+    _require_paramiko()
+    client = _make_client(host, port, username, password, timeout)
+    try:
+        ch = client.invoke_shell()
+        time.sleep(1)
+        ch.recv(RECV_CHUNK)
+        ch.send("config global\n")
+        time.sleep(0.5)
+        ch.recv(RECV_CHUNK)
+        ch.send("show full-configuration firewall policy\n")
+        return _read_until_idle(ch, timeout=45)
+    finally:
+        client.close()
+
+
+# ── Palo Alto Networks ────────────────────────────────────────────────────────
+
+def _pull_paloalto(host, port, username, password, timeout):
+    """Pull running config via PA CLI SSH command."""
+    _require_paramiko()
+    client = _make_client(host, port, username, password, timeout)
+    try:
+        stdin, stdout, stderr = client.exec_command(
+            "show config running", timeout=timeout
+        )
+        # PA can take several seconds to dump the XML
+        time.sleep(5)
+        out = stdout.read()
+        return out.decode("utf-8", errors="ignore")
+    finally:
+        client.close()
+
+
+# ── Main entrypoint ───────────────────────────────────────────────────────────
+
+_SUFFIXES = {"asa": ".txt", "fortinet": ".txt", "paloalto": ".xml"}
+_PULLERS  = {
+    "asa":      _pull_asa,
+    "fortinet": _pull_fortinet,
+    "paloalto": _pull_paloalto,
+}
+
+
+def connect_and_pull(vendor, host, port, username, password, timeout=30, upload_folder=None):
+    """
+    Connect to a live device, pull its running config, and save to a temp file.
+
+    Returns (temp_file_path, raw_content_str).
+    Raises RuntimeError / paramiko exceptions on failure.
+    """
+    puller = _PULLERS.get(vendor)
+    if puller is None:
+        raise ValueError(f"Live SSH not supported for vendor: {vendor}")
+
+    content = puller(host, int(port), username, password, int(timeout))
+
+    if not content or len(content.strip()) < 50:
+        raise RuntimeError(
+            "Device returned an empty or very short response. "
+            "Check credentials and that the account has sufficient privileges."
+        )
+
+    suffix = _SUFFIXES[vendor]
+    folder = upload_folder or tempfile.gettempdir()
+    tmp_path = os.path.join(folder, f"flintlock_live_{uuid.uuid4().hex}{suffix}")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    return tmp_path, content

--- a/src/flintlock/static/style.css
+++ b/src/flintlock/static/style.css
@@ -617,10 +617,264 @@ select:focus, input[type="text"]:focus {
 
 /* ===== Utilities ===== */
 .hidden { display: none !important; }
+.text-muted { color: var(--text-muted); font-size: 0.9rem; }
+.mt-xs { margin-top: 0.4rem; }
+.link-btn {
+  background: none; border: none; color: var(--compliance);
+  cursor: pointer; font-size: inherit; text-decoration: underline; padding: 0;
+}
+.link-btn:hover { opacity: 0.8; }
+
+/* ===== Tab navigation ===== */
+.tab-nav {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 2px solid var(--border);
+  margin-bottom: 0;
+  overflow-x: auto;
+}
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+}
+.tab-btn:hover { color: var(--text); }
+.tab-btn.tab-active { color: var(--compliance); border-bottom-color: var(--compliance); }
+
+/* ===== Tab panels ===== */
+.tab-panel { display: flex; flex-direction: column; gap: 1.5rem; padding-top: 1.5rem; }
+
+/* ===== Card description text ===== */
+.card-desc {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+  line-height: 1.5;
+}
+
+/* ===== Alert info variant ===== */
+.alert-info {
+  background: rgba(68,136,255,0.07);
+  border: 1px solid rgba(68,136,255,0.35);
+  color: var(--compliance);
+  margin-bottom: 1.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+/* ===== Connect form grid ===== */
+.connect-grid { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 700px) { .connect-grid { grid-template-columns: 1fr 1fr; } }
+
+/* ===== Archive / history row ===== */
+.archive-row { margin-top: 0.85rem; }
+.archive-saved-msg { font-size: 0.85rem; color: var(--pass); }
+
+/* ===== Small button variant ===== */
+.btn-sm { padding: 0.3rem 0.65rem !important; font-size: 0.8rem !important; }
+
+/* ===== Diff results ===== */
+.diff-stat-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+.diff-stat {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+.diff-stat-added     { background: rgba(26,128,85,0.1);  color: var(--pass);      border: 1px solid rgba(26,128,85,0.3); }
+.diff-stat-removed   { background: rgba(204,34,0,0.08);  color: var(--high);      border: 1px solid rgba(204,34,0,0.3); }
+.diff-stat-unchanged { background: var(--sev-total-bg);  color: var(--text-muted);border: 1px solid var(--border); }
+
+.diff-files {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  font-family: "Consolas","Menlo",monospace;
+}
+
+.diff-group-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.4rem 0.75rem;
+  margin-bottom: 0.25rem;
+  margin-top: 0.75rem;
+  border-radius: 4px;
+}
+.diff-added-label     { background: rgba(26,128,85,0.08); color: var(--pass); }
+.diff-removed-label   { background: rgba(204,34,0,0.07);  color: var(--high); }
+.diff-unchanged-label { background: var(--sev-total-bg);  color: var(--text-muted); }
+
+.diff-row {
+  font-size: 0.82rem;
+  font-family: "Consolas","Menlo",monospace;
+  padding: 0.4rem 0.75rem;
+  margin-bottom: 0.25rem;
+  border-radius: 4px;
+  border-left: 3px solid transparent;
+  word-break: break-all;
+}
+.diff-added     { background: rgba(26,128,85,0.06);  border-color: var(--pass);   color: var(--finding-pass-text); }
+.diff-removed   { background: rgba(204,34,0,0.06);   border-color: var(--high);   color: var(--finding-high-text); }
+.diff-unchanged { background: var(--sev-total-bg);   border-color: var(--border); color: var(--text-muted); }
+
+/* ===== History list ===== */
+.history-list { display: flex; flex-direction: column; gap: 0.4rem; }
+
+.history-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card-bg);
+  gap: 0.75rem;
+  transition: border-color 0.15s;
+}
+.history-entry:hover { border-color: var(--compliance); }
+
+.history-entry-left {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.history-check-wrap { cursor: pointer; flex-shrink: 0; }
+.history-check { width: 15px; height: 15px; accent-color: var(--compliance); cursor: pointer; }
+
+.history-entry-info { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
+
+.history-filename {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-meta { font-size: 0.75rem; color: var(--text-muted); }
+
+.history-entry-right {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.history-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 0.2rem 0.45rem;
+  border-radius: 5px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  border: 1px solid currentColor;
+}
+
+/* ===== History compare bar ===== */
+.history-compare-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.85rem;
+  margin-top: 0.5rem;
+  border: 1px dashed var(--border);
+  border-radius: 7px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  gap: 0.75rem;
+}
+
+/* ===== Comparison view ===== */
+.compare-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.compare-col {
+  flex: 1;
+  min-width: 160px;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--input-bg);
+}
+.compare-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+.compare-filename { font-size: 0.9rem; font-weight: 600; color: var(--text); word-break: break-all; }
+.compare-ts       { font-size: 0.75rem; color: var(--text-muted); margin: 0.2rem 0 0.5rem; }
+.compare-stats    { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+
+.compare-arrow {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: center;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.arrow-better  { background: rgba(26,128,85,0.1);  color: var(--pass);      border: 1px solid rgba(26,128,85,0.3); }
+.arrow-neutral { background: var(--sev-total-bg);  color: var(--text-muted);border: 1px solid var(--border); }
+.arrow-worse   { background: rgba(204,34,0,0.08);  color: var(--high);      border: 1px solid rgba(204,34,0,0.3); }
+
+.compare-delta-row {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.compare-delta-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--input-bg);
+  min-width: 80px;
+}
+.delta-label   { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.4px; color: var(--text-muted); margin-bottom: 0.25rem; }
+.delta-better  { color: var(--pass);      font-size: 1.3rem; font-weight: 700; }
+.delta-worse   { color: var(--high);      font-size: 1.3rem; font-weight: 700; }
+.delta-neutral { color: var(--text-muted);font-size: 1.3rem; font-weight: 700; }
 
 /* ===== Responsive ===== */
 @media (max-width: 600px) {
-  .form-grid { grid-template-columns: 1fr; }
-  .logo-sub  { display: none; }
-  .modal-box { max-width: 100%; }
+  .form-grid      { grid-template-columns: 1fr; }
+  .connect-grid   { grid-template-columns: 1fr; }
+  .logo-sub       { display: none; }
+  .modal-box      { max-width: 100%; }
+  .tab-btn        { padding: 0.55rem 0.75rem; font-size: 0.8rem; }
+  .compare-header { flex-direction: column; }
+  .compare-arrow  { width: 100%; text-align: center; }
 }

--- a/src/flintlock/static/style.css
+++ b/src/flintlock/static/style.css
@@ -878,3 +878,89 @@ select:focus, input[type="text"]:focus {
   .compare-header { flex-direction: column; }
   .compare-arrow  { width: 100%; text-align: center; }
 }
+
+/* ===== History Filters ===== */
+.history-filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.history-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.filter-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.history-filters select,
+.history-filters input {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card-bg);
+  color: var(--text);
+}
+
+/* ===== Activity Log ===== */
+.activity-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  background: var(--card-bg);
+  gap: 0.75rem;
+}
+.activity-entry-fail {
+  border-left: 3px solid var(--high);
+  background: color-mix(in srgb, var(--high) 5%, var(--card-bg));
+}
+.activity-entry-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  flex: 1;
+  min-width: 0;
+}
+.activity-entry-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.activity-action-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  white-space: nowrap;
+  margin-top: 0.15rem;
+}
+.activity-ok   { color: var(--pass);   font-weight: 600; font-size: 0.85rem; }
+.activity-fail { color: var(--high);   font-weight: 600; font-size: 0.85rem; }
+.activity-error {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--high);
+  margin-top: 0.15rem;
+  word-break: break-all;
+}

--- a/src/flintlock/templates/index.html
+++ b/src/flintlock/templates/index.html
@@ -6,7 +6,6 @@
   <title>Flintlock &mdash; Firewall Audit</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <script>
-    // Apply saved theme before paint to avoid flash
     (function () {
       const t = localStorage.getItem("flintlock-theme") || "light";
       document.documentElement.setAttribute("data-theme", t);
@@ -14,6 +13,7 @@
   </script>
 </head>
 <body>
+
   <!-- Header -->
   <header class="header">
     <div class="header-inner">
@@ -52,343 +52,706 @@
             <p class="status-warn">No active license. Compliance checks require a valid key.</p>
           {% endif %}
         </div>
-
         <p class="modal-label">Activate a license key</p>
         <form id="activateForm" class="modal-form">
           <input type="text" id="licenseKey" name="key" placeholder="XXXX-XXXX-XXXX-XXXX" maxlength="19" autocomplete="off" />
           <button type="submit" class="btn-secondary">Activate</button>
         </form>
-
         <form id="deactivateForm" class="modal-form mt-sm">
           <button type="submit" class="btn-danger">Deactivate License</button>
         </form>
-
         <div id="licenseMsg" class="license-msg hidden"></div>
       </div>
     </div>
   </div>
 
   <main class="main">
-    <!-- Audit Form -->
-    <section class="card">
-      <h2 class="card-title">Run Audit</h2>
-      <form id="auditForm" enctype="multipart/form-data">
-        <div class="form-grid">
-          <div class="form-group">
-            <label for="config">Config File</label>
-            <div class="file-input-wrapper">
-              <input type="file" id="config" name="config" required />
-              <span class="file-label" id="fileLabel">Choose a file&hellip;</span>
+
+    <!-- Tab nav -->
+    <nav class="tab-nav" role="tablist">
+      <button class="tab-btn tab-active" data-tab="audit"   role="tab">&#128196; File Audit</button>
+      <button class="tab-btn"            data-tab="diff"    role="tab">&#8646; Compare Configs</button>
+      <button class="tab-btn"            data-tab="connect" role="tab">&#128246; Live Connect</button>
+      <button class="tab-btn"            data-tab="history" role="tab">&#128337; Audit History</button>
+    </nav>
+
+    <!-- ══════════════════════════════════════════════ FILE AUDIT ══ -->
+    <section class="tab-panel" id="tab-audit">
+      <div class="card">
+        <h2 class="card-title">Run Audit</h2>
+        <form id="auditForm" enctype="multipart/form-data">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="config">Config File</label>
+              <div class="file-input-wrapper">
+                <input type="file" id="config" name="config" required />
+                <span class="file-label" id="fileLabel">Choose a file&hellip;</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="vendor">Vendor</label>
+              <select id="vendor" name="vendor">
+                <option value="auto" selected>Auto-detect (recommended)</option>
+                <option value="asa">Cisco</option>
+                <option value="paloalto">Palo Alto Networks</option>
+                <option value="fortinet">Fortinet</option>
+                <option value="pfsense">pfSense</option>
+                <option value="aws">AWS Security Group</option>
+                <option value="azure">Azure NSG</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="compliance">Compliance Framework <span class="optional">(licensed)</span></label>
+              <select id="compliance" name="compliance">
+                <option value="">None</option>
+                <option value="cis">CIS Benchmark</option>
+                <option value="pci">PCI-DSS</option>
+                <option value="nist">NIST SP 800-41</option>
+              </select>
+            </div>
+            <div class="form-group form-group-check">
+              <label class="checkbox-label">
+                <input type="checkbox" id="report" name="report" value="1" />
+                <span>Generate PDF Report</span>
+              </label>
+              <label class="checkbox-label mt-xs">
+                <input type="checkbox" id="archive" name="archive" value="1" />
+                <span>Save to Audit History</span>
+              </label>
             </div>
           </div>
+          <button type="submit" class="btn-primary" id="submitBtn">
+            <span id="submitText">Run Audit</span>
+            <span id="submitSpinner" class="spinner hidden"></span>
+          </button>
+        </form>
+      </div>
 
-          <div class="form-group">
-            <label for="vendor">Vendor</label>
-            <select id="vendor" name="vendor">
-              <option value="auto" selected>Auto-detect (recommended)</option>
-              <option value="asa">Cisco</option>
-              <option value="paloalto">Palo Alto Networks</option>
-              <option value="fortinet">Fortinet</option>
-              <option value="pfsense">pfSense</option>
-            </select>
-          </div>
-
-          <div class="form-group">
-            <label for="compliance">Compliance Framework <span class="optional">(licensed)</span></label>
-            <select id="compliance" name="compliance">
-              <option value="">None</option>
-              <option value="cis">CIS Benchmark</option>
-              <option value="pci">PCI-DSS</option>
-              <option value="nist">NIST SP 800-41</option>
-            </select>
-          </div>
-
-          <div class="form-group form-group-check">
-            <label class="checkbox-label">
-              <input type="checkbox" id="report" name="report" value="1" />
-              <span>Generate PDF Report</span>
-            </label>
-          </div>
+      <!-- Audit Results -->
+      <div class="card hidden" id="resultsSection">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Results</h2>
+          <span class="detected-vendor hidden" id="detectedVendorTag"></span>
         </div>
-
-        <button type="submit" class="btn-primary" id="submitBtn">
-          <span id="submitText">Run Audit</span>
-          <span id="submitSpinner" class="spinner hidden"></span>
-        </button>
-      </form>
-    </section>
-
-    <!-- Results -->
-    <section class="card hidden" id="resultsSection">
-      <div class="results-header">
-        <h2 class="card-title" style="margin-bottom:0">Results</h2>
-        <span class="detected-vendor hidden" id="detectedVendorTag"></span>
-      </div>
-
-      <!-- License warning -->
-      <div class="alert alert-warning hidden" id="licenseWarning"></div>
-
-      <!-- Summary counters -->
-      <div class="summary-grid" id="summaryGrid"></div>
-
-      <!-- Findings list -->
-      <div id="findingsList"></div>
-
-      <!-- PDF download -->
-      <div class="pdf-row hidden" id="pdfRow">
-        <a id="pdfLink" class="btn-download" href="#" download>&#8681; Download PDF Report</a>
+        <div class="alert alert-warning hidden" id="licenseWarning"></div>
+        <div class="summary-grid" id="summaryGrid"></div>
+        <div id="findingsList"></div>
+        <div class="pdf-row hidden" id="pdfRow">
+          <a id="pdfLink" class="btn-download" href="#" download>&#8681; Download PDF Report</a>
+        </div>
+        <div class="archive-row hidden" id="archiveRow">
+          <span class="archive-saved-msg">&#10003; Saved to Audit History &mdash;
+            <button class="link-btn" id="viewHistoryBtn">View History</button>
+          </span>
+        </div>
       </div>
     </section>
+
+    <!-- ═════════════════════════════════════════ COMPARE CONFIGS ══ -->
+    <section class="tab-panel hidden" id="tab-diff">
+      <div class="card">
+        <h2 class="card-title">Compare Configs</h2>
+        <p class="card-desc">Upload two firewall configs of the same vendor to see added, removed, and unchanged rules.</p>
+        <form id="diffForm" enctype="multipart/form-data">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="config_a">Baseline Config <span class="optional">(older)</span></label>
+              <div class="file-input-wrapper">
+                <input type="file" id="config_a" name="config_a" required />
+                <span class="file-label" id="fileLabelA">Choose a file&hellip;</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="config_b">New Config <span class="optional">(current)</span></label>
+              <div class="file-input-wrapper">
+                <input type="file" id="config_b" name="config_b" required />
+                <span class="file-label" id="fileLabelB">Choose a file&hellip;</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="diffVendor">Vendor</label>
+              <select id="diffVendor" name="vendor">
+                <option value="auto" selected>Auto-detect (recommended)</option>
+                <option value="asa">Cisco</option>
+                <option value="paloalto">Palo Alto Networks</option>
+                <option value="fortinet">Fortinet</option>
+                <option value="pfsense">pfSense</option>
+              </select>
+            </div>
+          </div>
+          <button type="submit" class="btn-primary" id="diffBtn">
+            <span id="diffText">Compare</span>
+            <span id="diffSpinner" class="spinner hidden"></span>
+          </button>
+        </form>
+      </div>
+
+      <div class="card hidden" id="diffResults">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Diff Results</h2>
+          <span class="detected-vendor hidden" id="diffVendorTag"></span>
+        </div>
+        <div id="diffSummary"></div>
+        <div id="diffAdded"></div>
+        <div id="diffRemoved"></div>
+        <div id="diffUnchanged"></div>
+      </div>
+    </section>
+
+    <!-- ══════════════════════════════════════════ LIVE CONNECT ══════ -->
+    <section class="tab-panel hidden" id="tab-connect">
+      <div class="card">
+        <h2 class="card-title">Live SSH Connection</h2>
+        <p class="card-desc">Connect directly to a device to pull its running configuration and audit it in real time.</p>
+        <div class="alert alert-info">
+          Supported: <strong>Cisco ASA</strong>, <strong>Fortinet</strong>, <strong>Palo Alto Networks</strong> (SSH).
+          Credentials are used only for the single connection and are never stored.
+        </div>
+        <form id="connectForm">
+          <div class="form-grid connect-grid">
+            <div class="form-group">
+              <label for="connVendor">Vendor</label>
+              <select id="connVendor" name="vendor">
+                <option value="asa">Cisco ASA</option>
+                <option value="fortinet">Fortinet</option>
+                <option value="paloalto">Palo Alto Networks</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="connHost">Host / IP</label>
+              <input type="text" id="connHost" name="host" placeholder="192.168.1.1" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="connPort">SSH Port</label>
+              <input type="text" id="connPort" name="port" value="22" placeholder="22" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="connUser">Username</label>
+              <input type="text" id="connUser" name="username" placeholder="admin" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="connPass">Password</label>
+              <input type="password" id="connPass" name="password" placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" autocomplete="current-password" />
+            </div>
+            <div class="form-group">
+              <label for="connCompliance">Compliance <span class="optional">(licensed)</span></label>
+              <select id="connCompliance" name="compliance">
+                <option value="">None</option>
+                <option value="cis">CIS Benchmark</option>
+                <option value="pci">PCI-DSS</option>
+                <option value="nist">NIST SP 800-41</option>
+              </select>
+            </div>
+          </div>
+          <button type="submit" class="btn-primary" id="connectBtn">
+            <span id="connectText">Connect &amp; Audit</span>
+            <span id="connectSpinner" class="spinner hidden"></span>
+          </button>
+        </form>
+      </div>
+
+      <div class="card hidden" id="connectResults">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Live Audit Results</h2>
+          <span class="detected-vendor hidden" id="connVendorTag"></span>
+        </div>
+        <div class="summary-grid" id="connSummaryGrid"></div>
+        <div id="connFindingsList"></div>
+        <div class="archive-row">
+          <span class="archive-saved-msg">&#10003; Result auto-saved to Audit History &mdash;
+            <button class="link-btn" id="connViewHistoryBtn">View History</button>
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═════════════════════════════════════════ AUDIT HISTORY ══════ -->
+    <section class="tab-panel hidden" id="tab-history">
+      <div class="card">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Audit History</h2>
+          <button class="btn-secondary" id="refreshHistoryBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#8635; Refresh</button>
+        </div>
+        <p class="card-desc">All saved audits. Check two entries to compare them.</p>
+        <div id="historyList" class="history-list">
+          <p class="text-muted">Loading&hellip;</p>
+        </div>
+      </div>
+
+      <!-- Comparison result -->
+      <div class="card hidden" id="compareResults">
+        <h2 class="card-title">Comparison</h2>
+        <div id="compareContent"></div>
+      </div>
+    </section>
+
   </main>
 
   <footer class="footer">
-    <p>Flintlock v1.0 &mdash; Firewall Security Auditor</p>
+    <p>Flintlock v1.1 &mdash; Firewall Security Auditor</p>
   </footer>
 
   <script>
-    // ── Theme toggle ──────────────────────────────────────────────
-    const html = document.documentElement;
-    const themeIcon = document.getElementById("themeIcon");
+  // ═══════════════════════════════════════════════════════════════ THEME ══
+  const html = document.documentElement;
+  const themeIcon = document.getElementById("themeIcon");
+  function applyTheme(theme) {
+    html.setAttribute("data-theme", theme);
+    themeIcon.innerHTML = theme === "dark" ? "&#9790;" : "&#9788;";
+    localStorage.setItem("flintlock-theme", theme);
+  }
+  applyTheme(html.getAttribute("data-theme") || "light");
+  document.getElementById("themeToggle").addEventListener("click", () =>
+    applyTheme(html.getAttribute("data-theme") === "dark" ? "light" : "dark")
+  );
 
-    function applyTheme(theme) {
-      html.setAttribute("data-theme", theme);
-      themeIcon.innerHTML = theme === "dark" ? "&#9790;" : "&#9788;";
-      localStorage.setItem("flintlock-theme", theme);
+  // ═══════════════════════════════════════════════════════ LICENSE MODAL ══
+  const modal = document.getElementById("licenseModal");
+  const openModal  = () => { modal.classList.remove("hidden"); document.body.style.overflow = "hidden"; document.getElementById("licenseKey").focus(); };
+  const closeModal = () => { modal.classList.add("hidden");    document.body.style.overflow = ""; };
+  document.getElementById("licenseBadgeBtn").addEventListener("click", openModal);
+  document.getElementById("modalClose").addEventListener("click", closeModal);
+  modal.addEventListener("click", e => { if (e.target === modal) closeModal(); });
+  document.addEventListener("keydown", e => { if (e.key === "Escape") closeModal(); });
+
+  document.getElementById("activateForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    const key  = document.getElementById("licenseKey").value.trim();
+    const res  = await fetch("/license/activate", { method: "POST", body: new URLSearchParams({ key }) });
+    const data = await res.json();
+    showLicenseMsg(data.message, data.success ? "ok" : "error");
+    if (data.success) refreshLicenseBadge(true, key.toUpperCase());
+  });
+  document.getElementById("deactivateForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    const res  = await fetch("/license/deactivate", { method: "POST" });
+    const data = await res.json();
+    showLicenseMsg(data.message, data.success ? "ok" : "error");
+    if (data.success) refreshLicenseBadge(false, null);
+  });
+  function showLicenseMsg(msg, type) {
+    const el = document.getElementById("licenseMsg");
+    el.textContent = msg;
+    el.className = "license-msg " + (type === "ok" ? "msg-ok" : "msg-error");
+    el.classList.remove("hidden");
+  }
+  function refreshLicenseBadge(licensed, key) {
+    const badge = document.getElementById("licenseBadge");
+    const status = document.getElementById("licenseStatus");
+    if (licensed) {
+      badge.className = "badge badge-active";
+      badge.innerHTML = "&#10003; Licensed";
+      status.innerHTML = `<p class="status-ok">&#10003; Active license: <code>${escHtml(key)}</code></p>`;
+    } else {
+      badge.className = "badge badge-unlicensed";
+      badge.innerHTML = "&#9888; Unlicensed";
+      status.innerHTML = `<p class="status-warn">No active license. Compliance checks require a valid key.</p>`;
     }
+  }
 
-    // Set icon on load to match stored preference
-    applyTheme(html.getAttribute("data-theme") || "light");
+  // ═══════════════════════════════════════════════════════════════ TABS ══
+  const tabBtns   = document.querySelectorAll(".tab-btn");
+  const tabPanels = document.querySelectorAll(".tab-panel");
+  function switchTab(tabId) {
+    tabBtns.forEach(b => b.classList.toggle("tab-active", b.dataset.tab === tabId));
+    tabPanels.forEach(p => p.classList.toggle("hidden", p.id !== "tab-" + tabId));
+    if (tabId === "history") loadHistory();
+  }
+  tabBtns.forEach(btn => btn.addEventListener("click", () => switchTab(btn.dataset.tab)));
 
-    document.getElementById("themeToggle").addEventListener("click", function () {
-      const next = html.getAttribute("data-theme") === "dark" ? "light" : "dark";
-      applyTheme(next);
-    });
+  // ═════════════════════════════════════════════════════ FILE AUDIT ══════
+  const VENDOR_LABELS = {
+    asa: "Cisco", paloalto: "Palo Alto Networks", fortinet: "Fortinet",
+    pfsense: "pfSense", aws: "AWS Security Group", azure: "Azure NSG"
+  };
 
-    // ── License modal ─────────────────────────────────────────────
-    const modal = document.getElementById("licenseModal");
+  document.getElementById("config").addEventListener("change", function () {
+    document.getElementById("fileLabel").textContent =
+      this.files.length ? this.files[0].name : "Choose a file\u2026";
+  });
 
-    function openModal() {
-      modal.classList.remove("hidden");
-      document.body.style.overflow = "hidden";
-      document.getElementById("licenseKey").focus();
+  // Filter state for audit results
+  let activeFilter = null;
+  document.getElementById("summaryGrid").addEventListener("click", function (e) {
+    const box = e.target.closest(".summary-box[data-filter]");
+    if (!box) return;
+    const filter = box.dataset.filter;
+    if (activeFilter === filter && filter !== "all") {
+      activeFilter = null; applyFindingFilter(null);
+      document.querySelectorAll("#summaryGrid .summary-box").forEach(b => b.classList.remove("filter-active"));
+    } else {
+      activeFilter = filter === "all" ? null : filter;
+      applyFindingFilter(activeFilter);
+      document.querySelectorAll("#summaryGrid .summary-box").forEach(b =>
+        b.classList.toggle("filter-active", b === box)
+      );
     }
+  });
 
-    function closeModal() {
-      modal.classList.add("hidden");
-      document.body.style.overflow = "";
+  function applyFindingFilter(filter) {
+    document.querySelectorAll("#findingsList .finding").forEach(f => {
+      if (!filter) { f.style.display = ""; return; }
+      const show =
+        filter === "high"       ? f.classList.contains("finding-high") :
+        filter === "medium"     ? f.classList.contains("finding-medium") :
+        filter === "compliance" ? (f.classList.contains("finding-compliance-high") || f.classList.contains("finding-compliance-medium")) :
+        true;
+      f.style.display = show ? "" : "none";
+    });
+  }
+
+  document.getElementById("auditForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    setLoading("submitBtn", "submitText", "submitSpinner", "Running\u2026", true);
+    try {
+      const res  = await fetch("/audit", { method: "POST", body: new FormData(this) });
+      const data = await res.json();
+      if (data.error) { showAuditError(data.error); return; }
+      renderResults(data);
+    } catch (err) {
+      showAuditError("Unexpected error: " + err.message);
+    } finally {
+      setLoading("submitBtn", "submitText", "submitSpinner", "Run Audit", false);
     }
+  });
 
-    document.getElementById("licenseBadgeBtn").addEventListener("click", openModal);
-    document.getElementById("modalClose").addEventListener("click", closeModal);
-    modal.addEventListener("click", function (e) {
-      if (e.target === modal) closeModal();
-    });
-    document.addEventListener("keydown", function (e) {
-      if (e.key === "Escape") closeModal();
-    });
+  function showAuditError(msg) {
+    const section = document.getElementById("resultsSection");
+    section.classList.remove("hidden");
+    ["summaryGrid"].forEach(id => document.getElementById(id).innerHTML = "");
+    document.getElementById("findingsList").innerHTML = `<div class="alert alert-error">${escHtml(msg)}</div>`;
+    ["pdfRow","archiveRow","licenseWarning"].forEach(id => document.getElementById(id).classList.add("hidden"));
+    document.getElementById("detectedVendorTag").classList.add("hidden");
+  }
 
-    // ── File input label ──────────────────────────────────────────
-    document.getElementById("config").addEventListener("change", function () {
-      document.getElementById("fileLabel").textContent =
-        this.files.length ? this.files[0].name : "Choose a file\u2026";
-    });
+  function renderResults(data) {
+    document.getElementById("resultsSection").classList.remove("hidden");
+    document.getElementById("resultsSection").scrollIntoView({ behavior: "smooth" });
 
-    // ── Audit form ────────────────────────────────────────────────
-    document.getElementById("auditForm").addEventListener("submit", async function (e) {
-      e.preventDefault();
-      const btn = document.getElementById("submitBtn");
-      const text = document.getElementById("submitText");
-      const spinner = document.getElementById("submitSpinner");
-      btn.disabled = true;
-      text.textContent = "Running\u2026";
-      spinner.classList.remove("hidden");
+    const tag = document.getElementById("detectedVendorTag");
+    if (data.detected_vendor) {
+      tag.textContent = "Detected: " + (VENDOR_LABELS[data.detected_vendor] || data.detected_vendor);
+      tag.classList.remove("hidden");
+    } else { tag.classList.add("hidden"); }
 
-      try {
-        const res = await fetch("/audit", { method: "POST", body: new FormData(this) });
-        const data = await res.json();
-        if (data.error) { showError(data.error); return; }
-        renderResults(data);
-      } catch (err) {
-        showError("Unexpected error: " + err.message);
-      } finally {
-        btn.disabled = false;
-        text.textContent = "Run Audit";
-        spinner.classList.add("hidden");
+    const warn = document.getElementById("licenseWarning");
+    if (data.license_warning) { warn.innerHTML = data.license_warning; warn.classList.remove("hidden"); }
+    else { warn.classList.add("hidden"); }
+
+    activeFilter = null; applyFindingFilter(null);
+    document.getElementById("summaryGrid").innerHTML = buildSummaryHTML(data.summary);
+
+    document.getElementById("findingsList").innerHTML = data.findings.length
+      ? data.findings.map(f => `<div class="finding ${findingClass(f)}">${escHtml(f)}</div>`).join("")
+      : `<div class="finding finding-pass">[PASS] No issues found</div>`;
+
+    const pdfRow = document.getElementById("pdfRow");
+    if (data.report) { document.getElementById("pdfLink").href = "/reports/" + data.report; pdfRow.classList.remove("hidden"); }
+    else { pdfRow.classList.add("hidden"); }
+
+    if (data.archive_id) { document.getElementById("archiveRow").classList.remove("hidden"); }
+    else { document.getElementById("archiveRow").classList.add("hidden"); }
+  }
+
+  document.getElementById("viewHistoryBtn").addEventListener("click", () => switchTab("history"));
+
+  // ══════════════════════════════════════════════════ COMPARE CONFIGS ══
+  document.getElementById("config_a").addEventListener("change", function () {
+    document.getElementById("fileLabelA").textContent = this.files.length ? this.files[0].name : "Choose a file\u2026";
+  });
+  document.getElementById("config_b").addEventListener("change", function () {
+    document.getElementById("fileLabelB").textContent = this.files.length ? this.files[0].name : "Choose a file\u2026";
+  });
+
+  document.getElementById("diffForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    setLoading("diffBtn", "diffText", "diffSpinner", "Comparing\u2026", true);
+    try {
+      const res  = await fetch("/diff", { method: "POST", body: new FormData(this) });
+      const data = await res.json();
+      if (data.error) {
+        document.getElementById("diffResults").classList.remove("hidden");
+        document.getElementById("diffSummary").innerHTML = `<div class="alert alert-error">${escHtml(data.error)}</div>`;
+        ["diffAdded","diffRemoved","diffUnchanged"].forEach(id => document.getElementById(id).innerHTML = "");
+        return;
       }
-    });
-
-    function showError(msg) {
-      const section = document.getElementById("resultsSection");
-      section.classList.remove("hidden");
-      document.getElementById("findingsList").innerHTML =
-        `<div class="alert alert-error">${escHtml(msg)}</div>`;
-      document.getElementById("summaryGrid").innerHTML = "";
-      document.getElementById("pdfRow").classList.add("hidden");
-      document.getElementById("licenseWarning").classList.add("hidden");
-      document.getElementById("detectedVendorTag").classList.add("hidden");
+      renderDiff(data);
+    } catch (err) {
+      document.getElementById("diffResults").classList.remove("hidden");
+      document.getElementById("diffSummary").innerHTML = `<div class="alert alert-error">Unexpected error: ${escHtml(err.message)}</div>`;
+    } finally {
+      setLoading("diffBtn", "diffText", "diffSpinner", "Compare", false);
     }
+  });
 
-    const VENDOR_LABELS = {
-      asa: "Cisco", paloalto: "Palo Alto Networks", fortinet: "Fortinet", pfsense: "pfSense"
+  function renderDiff(data) {
+    document.getElementById("diffResults").classList.remove("hidden");
+    document.getElementById("diffResults").scrollIntoView({ behavior: "smooth" });
+
+    const tag = document.getElementById("diffVendorTag");
+    tag.textContent = "Vendor: " + (VENDOR_LABELS[data.vendor] || data.vendor);
+    tag.classList.remove("hidden");
+
+    const added     = data.added     || [];
+    const removed   = data.removed   || [];
+    const unchanged = data.unchanged || [];
+
+    document.getElementById("diffSummary").innerHTML = `
+      <div class="diff-stat-row">
+        <span class="diff-stat diff-stat-added">+${added.length} added</span>
+        <span class="diff-stat diff-stat-removed">&#8722;${removed.length} removed</span>
+        <span class="diff-stat diff-stat-unchanged">${unchanged.length} unchanged</span>
+      </div>
+      <p class="diff-files">${escHtml(data.filename_a)} &rarr; ${escHtml(data.filename_b)}</p>`;
+
+    const renderGroup = (elId, items, cls, label) => {
+      const el = document.getElementById(elId);
+      if (!items.length) { el.innerHTML = ""; return; }
+      el.innerHTML = `<div class="diff-group-label ${cls}-label">${label} (${items.length})</div>` +
+        items.map(r => `<div class="diff-row ${cls}">${escHtml(r)}</div>`).join("");
     };
+    renderGroup("diffAdded",     added,     "diff-added",     "&#43; Added");
+    renderGroup("diffRemoved",   removed,   "diff-removed",   "&#8722; Removed");
+    renderGroup("diffUnchanged", unchanged, "diff-unchanged", "&#8799; Unchanged");
+  }
 
-    // ── Filter state ──────────────────────────────────────────────
-    let activeFilter = null;
-
-    document.getElementById("summaryGrid").addEventListener("click", function (e) {
-      const box = e.target.closest(".summary-box[data-filter]");
-      if (!box) return;
-      const filter = box.dataset.filter;
-
-      if (activeFilter === filter && filter !== "all") {
-        // Second click on same box → reset to show all
-        activeFilter = null;
-        applyFindingFilter(null);
-        document.querySelectorAll(".summary-box").forEach(b => b.classList.remove("filter-active"));
-      } else {
-        activeFilter = filter === "all" ? null : filter;
-        applyFindingFilter(activeFilter);
-        document.querySelectorAll(".summary-box").forEach(b =>
-          b.classList.toggle("filter-active", b === box)
-        );
+  // ════════════════════════════════════════════════════ LIVE CONNECT ══════
+  document.getElementById("connectForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    setLoading("connectBtn", "connectText", "connectSpinner", "Connecting\u2026", true);
+    try {
+      const res  = await fetch("/connect", { method: "POST", body: new URLSearchParams(new FormData(this)) });
+      const data = await res.json();
+      if (data.error) {
+        document.getElementById("connectResults").classList.remove("hidden");
+        document.getElementById("connFindingsList").innerHTML = `<div class="alert alert-error">${escHtml(data.error)}</div>`;
+        document.getElementById("connSummaryGrid").innerHTML  = "";
+        document.getElementById("connVendorTag").classList.add("hidden");
+        return;
       }
-    });
+      renderConnectResults(data);
+    } catch (err) {
+      document.getElementById("connectResults").classList.remove("hidden");
+      document.getElementById("connFindingsList").innerHTML = `<div class="alert alert-error">Unexpected error: ${escHtml(err.message)}</div>`;
+    } finally {
+      setLoading("connectBtn", "connectText", "connectSpinner", "Connect & Audit", false);
+    }
+  });
 
-    function applyFindingFilter(filter) {
-      document.querySelectorAll(".finding").forEach(f => {
-        if (!filter) {
-          f.style.display = "";
-          return;
+  function renderConnectResults(data) {
+    document.getElementById("connectResults").classList.remove("hidden");
+    document.getElementById("connectResults").scrollIntoView({ behavior: "smooth" });
+    const tag = document.getElementById("connVendorTag");
+    tag.textContent = (VENDOR_LABELS[data.detected_vendor] || data.detected_vendor) + " @ " + data.host;
+    tag.classList.remove("hidden");
+    document.getElementById("connSummaryGrid").innerHTML = buildSummaryHTML(data.summary);
+    document.getElementById("connFindingsList").innerHTML = data.findings.length
+      ? data.findings.map(f => `<div class="finding ${findingClass(f)}">${escHtml(f)}</div>`).join("")
+      : `<div class="finding finding-pass">[PASS] No issues found</div>`;
+  }
+  document.getElementById("connViewHistoryBtn").addEventListener("click", () => switchTab("history"));
+
+  // ════════════════════════════════════════════════ AUDIT HISTORY ══════
+  let historyData = [];
+  let compareSelections = [];
+
+  async function loadHistory() {
+    document.getElementById("historyList").innerHTML = `<p class="text-muted">Loading&hellip;</p>`;
+    try {
+      const res  = await fetch("/archive");
+      historyData = await res.json();
+      compareSelections = [];
+      renderHistory(historyData);
+    } catch (err) {
+      document.getElementById("historyList").innerHTML =
+        `<div class="alert alert-error">Failed to load history: ${escHtml(err.message)}</div>`;
+    }
+  }
+
+  function renderHistory(entries) {
+    const el = document.getElementById("historyList");
+    if (!entries.length) {
+      el.innerHTML = `<p class="text-muted">No audit history yet. Run an audit and check &ldquo;Save to Audit History&rdquo;.</p>`;
+      return;
+    }
+    el.innerHTML = entries.map(e => {
+      const ts     = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
+      const vendor = VENDOR_LABELS[e.vendor] || e.vendor;
+      const hi = e.summary?.high || 0, med = e.summary?.medium || 0, tot = e.summary?.total || 0;
+      return `<div class="history-entry" data-id="${escHtml(e.id)}">
+        <div class="history-entry-left">
+          <label class="history-check-wrap" title="Select to compare">
+            <input type="checkbox" class="history-check" data-id="${escHtml(e.id)}" />
+          </label>
+          <div class="history-entry-info">
+            <span class="history-filename">${escHtml(e.filename)}</span>
+            <span class="history-meta">${escHtml(vendor)} &bull; ${escHtml(ts)}</span>
+          </div>
+        </div>
+        <div class="history-entry-right">
+          <span class="history-badge sev-high" title="High">${hi}</span>
+          <span class="history-badge sev-medium" title="Medium">${med}</span>
+          <span class="history-badge sev-total" title="Total">${tot}</span>
+          <button class="btn-danger btn-sm" data-delete="${escHtml(e.id)}" title="Delete">&#128465;</button>
+        </div>
+      </div>`;
+    }).join("") + `
+    <div class="history-compare-bar" id="compareBar">
+      <span id="compareBarText">Select two entries to compare</span>
+      <button class="btn-primary btn-sm" id="compareBtn" disabled>Compare Selected</button>
+    </div>`;
+
+    el.querySelectorAll(".history-check").forEach(cb => {
+      cb.addEventListener("change", function () {
+        if (this.checked) {
+          if (compareSelections.length >= 2) {
+            const old = compareSelections.shift();
+            const oldCb = el.querySelector(`.history-check[data-id="${old}"]`);
+            if (oldCb) oldCb.checked = false;
+          }
+          compareSelections.push(this.dataset.id);
+        } else {
+          compareSelections = compareSelections.filter(id => id !== this.dataset.id);
         }
-        const show =
-          filter === "high"       ? f.classList.contains("finding-high") :
-          filter === "medium"     ? f.classList.contains("finding-medium") :
-          filter === "compliance" ? (f.classList.contains("finding-compliance-high") ||
-                                     f.classList.contains("finding-compliance-medium")) :
-          true;
-        f.style.display = show ? "" : "none";
+        updateCompareBar();
       });
-    }
-
-    function renderResults(data) {
-      const section = document.getElementById("resultsSection");
-      section.classList.remove("hidden");
-      section.scrollIntoView({ behavior: "smooth" });
-
-      // Detected vendor tag
-      const tag = document.getElementById("detectedVendorTag");
-      if (data.detected_vendor) {
-        tag.textContent = "Detected: " + (VENDOR_LABELS[data.detected_vendor] || data.detected_vendor);
-        tag.classList.remove("hidden");
-      } else {
-        tag.classList.add("hidden");
-      }
-
-      // License warning
-      const warn = document.getElementById("licenseWarning");
-      if (data.license_warning) {
-        warn.innerHTML = data.license_warning;
-        warn.classList.remove("hidden");
-      } else {
-        warn.classList.add("hidden");
-      }
-
-      // Reset filter state on new results
-      activeFilter = null;
-      applyFindingFilter(null);
-
-      // Summary boxes
-      const s = data.summary;
-      const summaryItems = [
-        { label: "High",   value: s.high,   cls: "sev-high",   filter: "high" },
-        { label: "Medium", value: s.medium, cls: "sev-medium", filter: "medium" },
-        { label: "Total",  value: s.total,  cls: "sev-total",  filter: "all" },
-      ];
-      if (s.pci_high || s.pci_medium) {
-        summaryItems.push({ label: "PCI High",   value: s.pci_high,   cls: "sev-compliance", filter: "compliance" });
-        summaryItems.push({ label: "PCI Medium", value: s.pci_medium, cls: "sev-compliance", filter: "compliance" });
-      }
-      if (s.cis_high || s.cis_medium) {
-        summaryItems.push({ label: "CIS High",   value: s.cis_high,   cls: "sev-compliance", filter: "compliance" });
-        summaryItems.push({ label: "CIS Medium", value: s.cis_medium, cls: "sev-compliance", filter: "compliance" });
-      }
-      if (s.nist_high || s.nist_medium) {
-        summaryItems.push({ label: "NIST High",   value: s.nist_high,   cls: "sev-compliance", filter: "compliance" });
-        summaryItems.push({ label: "NIST Medium", value: s.nist_medium, cls: "sev-compliance", filter: "compliance" });
-      }
-      document.getElementById("summaryGrid").innerHTML = summaryItems
-        .map(i => `<div class="summary-box ${i.cls}" data-filter="${i.filter}" title="Click to filter"><span class="summary-val">${i.value}</span><span class="summary-lbl">${i.label}</span></div>`)
-        .join("");
-
-      // Findings
-      const list = document.getElementById("findingsList");
-      list.innerHTML = data.findings.length
-        ? data.findings.map(f => `<div class="finding ${findingClass(f)}">${escHtml(f)}</div>`).join("")
-        : `<div class="finding finding-pass">[PASS] No issues found</div>`;
-
-      // PDF download
-      const pdfRow = document.getElementById("pdfRow");
-      if (data.report) {
-        document.getElementById("pdfLink").href = "/reports/" + data.report;
-        pdfRow.classList.remove("hidden");
-      } else {
-        pdfRow.classList.add("hidden");
-      }
-    }
-
-    function findingClass(f) {
-      if (f.includes("[HIGH]")   && !f.match(/PCI-|CIS-|NIST-/)) return "finding-high";
-      if (f.includes("[MEDIUM]") && !f.match(/PCI-|CIS-|NIST-/)) return "finding-medium";
-      if (f.match(/PCI-HIGH|CIS-HIGH|NIST-HIGH/))                 return "finding-compliance-high";
-      if (f.match(/PCI-MEDIUM|CIS-MEDIUM|NIST-MEDIUM/))           return "finding-compliance-medium";
-      return "finding-info";
-    }
-
-    function escHtml(s) {
-      return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    }
-
-    // ── License activate ──────────────────────────────────────────
-    document.getElementById("activateForm").addEventListener("submit", async function (e) {
-      e.preventDefault();
-      const key = document.getElementById("licenseKey").value.trim();
-      const res = await fetch("/license/activate", {
-        method: "POST", body: new URLSearchParams({ key }),
-      });
-      const data = await res.json();
-      showLicenseMsg(data.message, data.success ? "ok" : "error");
-      if (data.success) refreshLicenseBadge(true, key.toUpperCase());
     });
 
-    // ── License deactivate ────────────────────────────────────────
-    document.getElementById("deactivateForm").addEventListener("submit", async function (e) {
-      e.preventDefault();
-      const res = await fetch("/license/deactivate", { method: "POST" });
-      const data = await res.json();
-      showLicenseMsg(data.message, data.success ? "ok" : "error");
-      if (data.success) refreshLicenseBadge(false, null);
+    el.querySelectorAll("[data-delete]").forEach(btn => {
+      btn.addEventListener("click", async function () {
+        await fetch("/archive/" + this.dataset.delete, { method: "DELETE" });
+        await loadHistory();
+      });
     });
 
-    function showLicenseMsg(msg, type) {
-      const el = document.getElementById("licenseMsg");
-      el.textContent = msg;
-      el.className = "license-msg " + (type === "ok" ? "msg-ok" : "msg-error");
-      el.classList.remove("hidden");
-    }
+    document.getElementById("compareBtn").addEventListener("click", runCompare);
+  }
 
-    function refreshLicenseBadge(licensed, key) {
-      const badge = document.getElementById("licenseBadge");
-      const status = document.getElementById("licenseStatus");
-      if (licensed) {
-        badge.className = "badge badge-active";
-        badge.innerHTML = "&#10003; Licensed";
-        status.innerHTML = `<p class="status-ok">&#10003; Active license: <code>${escHtml(key)}</code></p>`;
-      } else {
-        badge.className = "badge badge-unlicensed";
-        badge.innerHTML = "&#9888; Unlicensed";
-        status.innerHTML = `<p class="status-warn">No active license. Compliance checks require a valid key.</p>`;
-      }
+  function updateCompareBar() {
+    const btn  = document.getElementById("compareBtn");
+    const text = document.getElementById("compareBarText");
+    const n    = compareSelections.length;
+    btn.disabled = n < 2;
+    text.textContent = n === 0 ? "Select two entries to compare" :
+                       n === 1 ? "Select one more entry" : "Ready to compare";
+  }
+
+  async function runCompare() {
+    if (compareSelections.length < 2) return;
+    const [id_a, id_b] = compareSelections;
+    try {
+      const res  = await fetch("/archive/compare", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id_a, id_b }),
+      });
+      const data = await res.json();
+      if (data.error) { alert("Compare error: " + data.error); return; }
+      renderComparison(data);
+    } catch (err) {
+      alert("Failed to compare: " + err.message);
     }
+  }
+
+  function renderComparison(data) {
+    const section = document.getElementById("compareResults");
+    section.classList.remove("hidden");
+    section.scrollIntoView({ behavior: "smooth" });
+
+    const ea = data.entry_a, eb = data.entry_b, d = data.delta;
+    const tsA = ea.timestamp ? new Date(ea.timestamp).toLocaleString() : "—";
+    const tsB = eb.timestamp ? new Date(eb.timestamp).toLocaleString() : "—";
+
+    const deltaStr = v =>
+      v > 0 ? `<span class="delta-worse">+${v}</span>` :
+      v < 0 ? `<span class="delta-better">${v}</span>` :
+      `<span class="delta-neutral">0</span>`;
+
+    const dirLabel = data.improved   ? "&#8679; Improved" :
+                     d.total === 0   ? "&#8596; No change" : "&#8681; Regressed";
+    const dirClass = data.improved   ? "arrow-better" :
+                     d.total === 0   ? "arrow-neutral" : "arrow-worse";
+
+    document.getElementById("compareContent").innerHTML = `
+      <div class="compare-header">
+        <div class="compare-col">
+          <div class="compare-label">Baseline</div>
+          <div class="compare-filename">${escHtml(ea.filename)}</div>
+          <div class="compare-ts">${escHtml(tsA)}</div>
+          <div class="compare-stats">
+            <span class="sev-high history-badge">${ea.summary.high} High</span>
+            <span class="sev-medium history-badge">${ea.summary.medium} Med</span>
+          </div>
+        </div>
+        <div class="compare-arrow ${dirClass}">${dirLabel}</div>
+        <div class="compare-col">
+          <div class="compare-label">Current</div>
+          <div class="compare-filename">${escHtml(eb.filename)}</div>
+          <div class="compare-ts">${escHtml(tsB)}</div>
+          <div class="compare-stats">
+            <span class="sev-high history-badge">${eb.summary.high} High</span>
+            <span class="sev-medium history-badge">${eb.summary.medium} Med</span>
+          </div>
+        </div>
+      </div>
+      <div class="compare-delta-row">
+        <div class="compare-delta-box"><span class="delta-label">High &Delta;</span>${deltaStr(d.high)}</div>
+        <div class="compare-delta-box"><span class="delta-label">Medium &Delta;</span>${deltaStr(d.medium)}</div>
+        <div class="compare-delta-box"><span class="delta-label">Total &Delta;</span>${deltaStr(d.total)}</div>
+      </div>
+      ${data.resolved_findings.length ? `
+        <div class="diff-group-label diff-added-label">&#10003; Resolved Issues (${data.resolved_findings.length})</div>
+        ${data.resolved_findings.map(f => `<div class="diff-row diff-added">${escHtml(f)}</div>`).join("")}
+      ` : ""}
+      ${data.new_findings.length ? `
+        <div class="diff-group-label diff-removed-label">&#9888; New Issues (${data.new_findings.length})</div>
+        ${data.new_findings.map(f => `<div class="diff-row diff-removed">${escHtml(f)}</div>`).join("")}
+      ` : ""}
+      ${!data.resolved_findings.length && !data.new_findings.length ? `
+        <div class="finding finding-pass">[PASS] No change in findings between the two audits.</div>
+      ` : ""}`;
+  }
+
+  document.getElementById("refreshHistoryBtn").addEventListener("click", loadHistory);
+
+  // ══════════════════════════════════════════════════════════ HELPERS ══
+  function buildSummaryHTML(s) {
+    const items = [
+      { label: "High",   value: s.high,   cls: "sev-high",   filter: "high" },
+      { label: "Medium", value: s.medium, cls: "sev-medium", filter: "medium" },
+      { label: "Total",  value: s.total,  cls: "sev-total",  filter: "all" },
+    ];
+    if (s.pci_high  || s.pci_medium)  { items.push({ label:"PCI High",   value:s.pci_high,   cls:"sev-compliance",filter:"compliance"}); items.push({ label:"PCI Med",    value:s.pci_medium, cls:"sev-compliance",filter:"compliance"}); }
+    if (s.cis_high  || s.cis_medium)  { items.push({ label:"CIS High",   value:s.cis_high,   cls:"sev-compliance",filter:"compliance"}); items.push({ label:"CIS Med",    value:s.cis_medium, cls:"sev-compliance",filter:"compliance"}); }
+    if (s.nist_high || s.nist_medium) { items.push({ label:"NIST High",  value:s.nist_high,  cls:"sev-compliance",filter:"compliance"}); items.push({ label:"NIST Med",   value:s.nist_medium,cls:"sev-compliance",filter:"compliance"}); }
+    return items.map(i =>
+      `<div class="summary-box ${i.cls}" data-filter="${i.filter}" title="Click to filter">
+         <span class="summary-val">${i.value}</span><span class="summary-lbl">${i.label}</span>
+       </div>`
+    ).join("");
+  }
+
+  function findingClass(f) {
+    if (f.includes("[HIGH]")   && !f.match(/PCI-|CIS-|NIST-/)) return "finding-high";
+    if (f.includes("[MEDIUM]") && !f.match(/PCI-|CIS-|NIST-/)) return "finding-medium";
+    if (f.match(/PCI-HIGH|CIS-HIGH|NIST-HIGH/))                 return "finding-compliance-high";
+    if (f.match(/PCI-MEDIUM|CIS-MEDIUM|NIST-MEDIUM/))           return "finding-compliance-medium";
+    return "finding-info";
+  }
+
+  function setLoading(btnId, textId, spinnerId, label, loading) {
+    const btn = document.getElementById(btnId);
+    btn.disabled = loading;
+    document.getElementById(textId).textContent = loading ? label : label.replace(/\u2026$/, "").trim();
+    document.getElementById(spinnerId).classList.toggle("hidden", !loading);
+    if (!loading) {
+      const origLabels = { submitBtn:"Run Audit", diffBtn:"Compare", connectBtn:"Connect & Audit" };
+      document.getElementById(textId).textContent = origLabels[btnId] || label;
+    }
+  }
+
+  function escHtml(s) {
+    return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+  }
   </script>
 </body>
 </html>

--- a/src/flintlock/templates/index.html
+++ b/src/flintlock/templates/index.html
@@ -69,10 +69,11 @@
 
     <!-- Tab nav -->
     <nav class="tab-nav" role="tablist">
-      <button class="tab-btn tab-active" data-tab="audit"   role="tab">&#128196; File Audit</button>
-      <button class="tab-btn"            data-tab="diff"    role="tab">&#8646; Compare Configs</button>
-      <button class="tab-btn"            data-tab="connect" role="tab">&#128246; Live Connect</button>
-      <button class="tab-btn"            data-tab="history" role="tab">&#128337; Audit History</button>
+      <button class="tab-btn tab-active" data-tab="audit"    role="tab">&#128196; File Audit</button>
+      <button class="tab-btn"            data-tab="diff"     role="tab">&#8646; Compare Configs</button>
+      <button class="tab-btn"            data-tab="connect"  role="tab">&#128246; Live Connect</button>
+      <button class="tab-btn"            data-tab="history"  role="tab">&#128337; Audit History</button>
+      <button class="tab-btn"            data-tab="activity" role="tab">&#128203; Activity Log</button>
     </nav>
 
     <!-- ══════════════════════════════════════════════ FILE AUDIT ══ -->
@@ -257,8 +258,8 @@
         </div>
         <div class="summary-grid" id="connSummaryGrid"></div>
         <div id="connFindingsList"></div>
-        <div class="archive-row">
-          <span class="archive-saved-msg">&#10003; Result auto-saved to Audit History &mdash;
+        <div class="archive-row hidden" id="connArchiveRow">
+          <span class="archive-saved-msg">&#10003; Result saved to Audit History &mdash;
             <button class="link-btn" id="connViewHistoryBtn">View History</button>
           </span>
         </div>
@@ -272,7 +273,35 @@
           <h2 class="card-title" style="margin-bottom:0">Audit History</h2>
           <button class="btn-secondary" id="refreshHistoryBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#8635; Refresh</button>
         </div>
-        <p class="card-desc">All saved audits. Check two entries to compare them.</p>
+        <p class="card-desc">Saved audits. Select two entries and click Compare.</p>
+        <!-- Filters -->
+        <div class="history-filters">
+          <div class="history-filter-group">
+            <label class="filter-label">Vendor</label>
+            <select id="historyVendorFilter">
+              <option value="">All vendors</option>
+              <option value="asa">Cisco</option>
+              <option value="paloalto">Palo Alto Networks</option>
+              <option value="fortinet">Fortinet</option>
+              <option value="pfsense">pfSense</option>
+              <option value="aws">AWS Security Group</option>
+              <option value="azure">Azure NSG</option>
+            </select>
+          </div>
+          <div class="history-filter-group">
+            <label class="filter-label">Sort by</label>
+            <select id="historySort">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="most">Most issues</option>
+              <option value="least">Least issues</option>
+            </select>
+          </div>
+          <div class="history-filter-group">
+            <label class="filter-label">Search</label>
+            <input type="text" id="historySearch" placeholder="Filter by filename&hellip;" style="padding:0.3rem 0.6rem;font-size:0.85rem;" />
+          </div>
+        </div>
         <div id="historyList" class="history-list">
           <p class="text-muted">Loading&hellip;</p>
         </div>
@@ -282,6 +311,23 @@
       <div class="card hidden" id="compareResults">
         <h2 class="card-title">Comparison</h2>
         <div id="compareContent"></div>
+      </div>
+    </section>
+
+    <!-- ══════════════════════════════════════════ ACTIVITY LOG ══════ -->
+    <section class="tab-panel hidden" id="tab-activity">
+      <div class="card">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Activity Log</h2>
+          <div style="display:flex;gap:0.5rem;align-items:center;">
+            <button class="btn-secondary" id="refreshActivityBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#8635; Refresh</button>
+            <button class="btn-danger"    id="clearActivityBtn"   style="font-size:0.8rem;padding:0.3rem 0.75rem">&#128465; Clear All</button>
+          </div>
+        </div>
+        <p class="card-desc">All application activity — audits, SSH connections, and config diffs — including failures.</p>
+        <div id="activityList" class="history-list">
+          <p class="text-muted">Loading&hellip;</p>
+        </div>
       </div>
     </section>
 
@@ -355,7 +401,8 @@
   function switchTab(tabId) {
     tabBtns.forEach(b => b.classList.toggle("tab-active", b.dataset.tab === tabId));
     tabPanels.forEach(p => p.classList.toggle("hidden", p.id !== "tab-" + tabId));
-    if (tabId === "history") loadHistory();
+    if (tabId === "history")  loadHistory();
+    if (tabId === "activity") loadActivity();
   }
   tabBtns.forEach(btn => btn.addEventListener("click", () => switchTab(btn.dataset.tab)));
 
@@ -548,6 +595,10 @@
     document.getElementById("connFindingsList").innerHTML = data.findings.length
       ? data.findings.map(f => `<div class="finding ${findingClass(f)}">${escHtml(f)}</div>`).join("")
       : `<div class="finding finding-pass">[PASS] No issues found</div>`;
+    // Only show the archive-saved banner when the audit actually saved
+    const connArchiveRow = document.getElementById("connArchiveRow");
+    if (data.archive_id) connArchiveRow.classList.remove("hidden");
+    else connArchiveRow.classList.add("hidden");
   }
   document.getElementById("connViewHistoryBtn").addEventListener("click", () => switchTab("history"));
 
@@ -561,12 +612,34 @@
       const res  = await fetch("/archive");
       historyData = await res.json();
       compareSelections = [];
-      renderHistory(historyData);
+      applyHistoryFilters();
     } catch (err) {
       document.getElementById("historyList").innerHTML =
         `<div class="alert alert-error">Failed to load history: ${escHtml(err.message)}</div>`;
     }
   }
+
+  function applyHistoryFilters() {
+    const vendorFilter = document.getElementById("historyVendorFilter").value;
+    const sortMode     = document.getElementById("historySort").value;
+    const search       = document.getElementById("historySearch").value.trim().toLowerCase();
+
+    let entries = historyData.slice();
+    if (vendorFilter) entries = entries.filter(e => e.vendor === vendorFilter);
+    if (search)       entries = entries.filter(e => (e.filename || "").toLowerCase().includes(search));
+
+    if (sortMode === "newest")  entries.sort((a, b) => (b.timestamp || "").localeCompare(a.timestamp || ""));
+    if (sortMode === "oldest")  entries.sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+    if (sortMode === "most")    entries.sort((a, b) => (b.summary?.total || 0) - (a.summary?.total || 0));
+    if (sortMode === "least")   entries.sort((a, b) => (a.summary?.total || 0) - (b.summary?.total || 0));
+
+    renderHistory(entries);
+  }
+
+  ["historyVendorFilter", "historySort"].forEach(id =>
+    document.getElementById(id).addEventListener("change", applyHistoryFilters)
+  );
+  document.getElementById("historySearch").addEventListener("input", applyHistoryFilters);
 
   function renderHistory(entries) {
     const el = document.getElementById("historyList");
@@ -638,7 +711,11 @@
 
   async function runCompare() {
     if (compareSelections.length < 2) return;
-    const [id_a, id_b] = compareSelections;
+    // Always put the older entry as baseline (id_a) regardless of selection order
+    const entries = compareSelections.map(id => historyData.find(e => e.id === id)).filter(Boolean);
+    entries.sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+    const id_a = entries[0].id;
+    const id_b = entries[1].id;
     try {
       const res  = await fetch("/archive/compare", {
         method: "POST", headers: { "Content-Type": "application/json" },
@@ -712,6 +789,69 @@
   }
 
   document.getElementById("refreshHistoryBtn").addEventListener("click", loadHistory);
+
+  // ════════════════════════════════════════════════ ACTIVITY LOG ══════
+  const ACTION_LABELS = {
+    file_audit:      "File Audit",
+    ssh_connect:     "Live SSH",
+    config_diff:     "Config Diff",
+    archive_compare: "Comparison",
+  };
+
+  async function loadActivity() {
+    document.getElementById("activityList").innerHTML = `<p class="text-muted">Loading&hellip;</p>`;
+    try {
+      const res    = await fetch("/activity");
+      const events = await res.json();
+      renderActivity(events);
+    } catch (err) {
+      document.getElementById("activityList").innerHTML =
+        `<div class="alert alert-error">Failed to load activity: ${escHtml(err.message)}</div>`;
+    }
+  }
+
+  function renderActivity(events) {
+    const el = document.getElementById("activityList");
+    if (!events.length) {
+      el.innerHTML = `<p class="text-muted">No activity yet.</p>`;
+      return;
+    }
+    el.innerHTML = events.map(e => {
+      const ts     = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
+      const action = ACTION_LABELS[e.action] || e.action;
+      const vendor = VENDOR_LABELS[e.vendor] || e.vendor || "";
+      const ok     = e.success;
+      const errMsg = e.error ? `<span class="activity-error">${escHtml(e.error)}</span>` : "";
+      return `<div class="activity-entry ${ok ? "" : "activity-entry-fail"}">
+        <div class="activity-entry-left">
+          <span class="activity-action-badge">${escHtml(action)}</span>
+          <div class="history-entry-info">
+            <span class="history-filename">${escHtml(e.label)}</span>
+            <span class="history-meta">${vendor ? escHtml(vendor) + " &bull; " : ""}${escHtml(ts)}</span>
+            ${errMsg}
+          </div>
+        </div>
+        <div class="activity-entry-right">
+          <span class="${ok ? "activity-ok" : "activity-fail"}">${ok ? "&#10003; OK" : "&#10007; Failed"}</span>
+          <button class="btn-danger btn-sm" data-delete-activity="${escHtml(e.id)}" title="Delete">&#128465;</button>
+        </div>
+      </div>`;
+    }).join("");
+
+    el.querySelectorAll("[data-delete-activity]").forEach(btn => {
+      btn.addEventListener("click", async function () {
+        await fetch("/activity/" + this.dataset.deleteActivity, { method: "DELETE" });
+        await loadActivity();
+      });
+    });
+  }
+
+  document.getElementById("refreshActivityBtn").addEventListener("click", loadActivity);
+  document.getElementById("clearActivityBtn").addEventListener("click", async function () {
+    if (!confirm("Clear all activity log entries?")) return;
+    await fetch("/activity/clear", { method: "POST" });
+    await loadActivity();
+  });
 
   // ══════════════════════════════════════════════════════════ HELPERS ══
   function buildSummaryHTML(s) {

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -20,12 +20,17 @@ from .azure import audit_azure_nsg
 from .reporter import generate_report
 from .diff import diff_configs
 from .archive import save_audit, list_archive, get_entry, delete_entry, compare_entries
+from .activity_log import (
+    log_activity, list_activity, delete_activity_entry, clear_activity,
+    ACTION_FILE_AUDIT, ACTION_SSH_CONNECT, ACTION_CONFIG_DIFF, ACTION_COMPARISON,
+)
 
-UPLOAD_FOLDER  = os.environ.get("UPLOAD_FOLDER",  "/tmp/flintlock_uploads")
-REPORTS_FOLDER = os.environ.get("REPORTS_FOLDER", "/tmp/flintlock_reports")
-ARCHIVE_FOLDER = os.environ.get("ARCHIVE_FOLDER", "/tmp/flintlock_archive")
+UPLOAD_FOLDER    = os.environ.get("UPLOAD_FOLDER",    "/tmp/flintlock_uploads")
+REPORTS_FOLDER   = os.environ.get("REPORTS_FOLDER",   "/tmp/flintlock_reports")
+ARCHIVE_FOLDER   = os.environ.get("ARCHIVE_FOLDER",   "/tmp/flintlock_archive")
+ACTIVITY_FOLDER  = os.environ.get("ACTIVITY_FOLDER",  "/tmp/flintlock_activity")
 
-for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER):
+for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER, ACTIVITY_FOLDER):
     os.makedirs(_d, exist_ok=True)
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
@@ -313,10 +318,17 @@ def run_audit():
         findings = _sort_findings(findings)
         summary  = _build_summary(findings)
 
-        # Optional auto-archive
+        # Optional archive save
         archive_id = None
         if archive_it:
             archive_id, _ = save_audit(upload.filename, vendor, findings, summary, config_path=temp_path)
+
+        # Always log activity
+        log_activity(
+            ACTION_FILE_AUDIT, upload.filename, vendor=vendor, success=True,
+            details={"total": summary.get("total", 0), "high": summary.get("high", 0),
+                     "archived": archive_id is not None},
+        )
 
         return jsonify({
             "findings":        findings,
@@ -328,6 +340,8 @@ def run_audit():
         })
 
     except Exception as e:
+        log_activity(ACTION_FILE_AUDIT, upload.filename, vendor=vendor or "unknown",
+                     success=False, error=str(e))
         return jsonify({"error": str(e)}), 500
     finally:
         if os.path.exists(temp_path):
@@ -371,9 +385,19 @@ def run_diff():
         result["vendor"]     = vendor
         result["filename_a"] = upload_a.filename
         result["filename_b"] = upload_b.filename
+
+        log_activity(ACTION_CONFIG_DIFF,
+                     f"{upload_a.filename} → {upload_b.filename}",
+                     vendor=vendor, success=True,
+                     details={"added": len(result.get("added", [])),
+                               "removed": len(result.get("removed", [])),
+                               "unchanged": len(result.get("unchanged", []))})
         return jsonify(result)
 
     except Exception as e:
+        log_activity(ACTION_CONFIG_DIFF,
+                     f"{upload_a.filename} → {upload_b.filename}",
+                     vendor=vendor or "unknown", success=False, error=str(e))
         return jsonify({"error": str(e)}), 500
     finally:
         for p in (path_a, path_b):
@@ -397,6 +421,8 @@ def live_connect():
     if vendor not in ("asa", "fortinet", "paloalto"):
         return jsonify({"error": f"Live SSH not supported for vendor '{vendor}'. Supported: asa, fortinet, paloalto"}), 400
 
+    label = f"{vendor.upper()}@{host}"
+
     try:
         from .ssh_connector import connect_and_pull
         temp_path, _ = connect_and_pull(
@@ -404,6 +430,9 @@ def live_connect():
             timeout=30, upload_folder=UPLOAD_FOLDER
         )
     except Exception as e:
+        # Log the failed attempt to activity log only — do NOT save to Audit History
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=False, error=str(e),
+                     details={"host": host, "port": port})
         return jsonify({"error": f"Connection failed: {e}"}), 500
 
     try:
@@ -441,8 +470,13 @@ def live_connect():
         findings = _sort_findings(findings)
         summary  = _build_summary(findings)
 
-        label = f"{vendor.upper()}@{host}"
+        # Save successful SSH audits to Audit History
         archive_id, _ = save_audit(label, vendor, findings, summary, config_path=temp_path)
+
+        # Log successful activity
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=True,
+                     details={"host": host, "port": port,
+                              "total": summary.get("total", 0), "high": summary.get("high", 0)})
 
         return jsonify({
             "findings":        findings,
@@ -453,9 +487,11 @@ def live_connect():
         })
 
     except Exception as e:
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=False, error=str(e),
+                     details={"host": host, "port": port})
         return jsonify({"error": str(e)}), 500
     finally:
-        if os.path.exists(temp_path):
+        if "temp_path" in dir() and os.path.exists(temp_path):
             os.remove(temp_path)
 
 
@@ -505,6 +541,26 @@ def archive_compare():
     if error:
         return jsonify({"error": error}), 404
     return jsonify(result)
+
+
+# ── Activity Log API ──────────────────────────────────────────────────────────
+
+@app.route("/activity", methods=["GET"])
+def activity_list():
+    limit = int(request.args.get("limit", 200))
+    return jsonify(list_activity(limit=limit))
+
+
+@app.route("/activity/<event_id>", methods=["DELETE"])
+def activity_delete(event_id):
+    deleted = delete_activity_entry(event_id)
+    return jsonify({"deleted": deleted})
+
+
+@app.route("/activity/clear", methods=["POST"])
+def activity_clear():
+    count = clear_activity()
+    return jsonify({"cleared": count})
 
 
 # ── Reports / License ─────────────────────────────────────────────────────────

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -1,7 +1,8 @@
 import os
 import uuid
 from pathlib import Path
-from flask import Flask, render_template, request, jsonify, send_file, redirect, url_for
+from flask import Flask, render_template, request, jsonify, send_file
+
 from ciscoconfparse import CiscoConfParse
 
 from .license import check_license, activate_license, deactivate_license
@@ -14,33 +15,65 @@ from .compliance import (
 from .paloalto import audit_paloalto, parse_paloalto
 from .fortinet import audit_fortinet
 from .pfsense import audit_pfsense
+from .aws import audit_aws_sg
+from .azure import audit_azure_nsg
 from .reporter import generate_report
+from .diff import diff_configs
+from .archive import save_audit, list_archive, get_entry, delete_entry, compare_entries
 
-UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/flintlock_uploads")
+UPLOAD_FOLDER  = os.environ.get("UPLOAD_FOLDER",  "/tmp/flintlock_uploads")
 REPORTS_FOLDER = os.environ.get("REPORTS_FOLDER", "/tmp/flintlock_reports")
+ARCHIVE_FOLDER = os.environ.get("ARCHIVE_FOLDER", "/tmp/flintlock_archive")
 
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-os.makedirs(REPORTS_FOLDER, exist_ok=True)
+for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER):
+    os.makedirs(_d, exist_ok=True)
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
 app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10 MB upload limit
 
 
 VENDOR_DISPLAY = {
-    "asa":       "Cisco",
-    "paloalto":  "Palo Alto Networks",
-    "fortinet":  "Fortinet",
-    "pfsense":   "pfSense",
+    "asa":      "Cisco",
+    "paloalto": "Palo Alto Networks",
+    "fortinet": "Fortinet",
+    "pfsense":  "pfSense",
+    "aws":      "AWS Security Group",
+    "azure":    "Azure NSG",
 }
 
+ALL_VENDORS = set(VENDOR_DISPLAY)
 
-# --- Vendor auto-detection and validation ---
+
+# ── Vendor auto-detection ─────────────────────────────────────────────────────
 
 def detect_vendor(content: str, filename: str) -> str | None:
     """Infer firewall vendor from file content and filename."""
     filename_lower = filename.lower()
-    content_lower = content.lower()
-    stripped = content.strip()
+    content_lower  = content.lower()
+    stripped       = content.strip()
+
+    # JSON-based: AWS or Azure
+    if stripped.startswith("{") or stripped.startswith("[") or filename_lower.endswith(".json"):
+        try:
+            import json
+            data = json.loads(content[:8192])  # partial parse for detection
+            if isinstance(data, dict):
+                if "SecurityGroups" in data or "GroupId" in data or "IpPermissions" in data:
+                    return "aws"
+                if "securityRules" in data or "defaultSecurityRules" in data:
+                    return "azure"
+                if isinstance(data.get("value"), list):
+                    # Could be az network nsg list output
+                    if data["value"] and "securityRules" in data["value"][0]:
+                        return "azure"
+            elif isinstance(data, list) and data:
+                first = data[0]
+                if "GroupId" in first or "IpPermissions" in first:
+                    return "aws"
+                if "securityRules" in first or "defaultSecurityRules" in first:
+                    return "azure"
+        except Exception:
+            pass
 
     # XML-based: pfSense or Palo Alto
     if stripped.startswith("<") or filename_lower.endswith(".xml"):
@@ -65,26 +98,25 @@ def detect_vendor(content: str, filename: str) -> str | None:
 def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bool, str]:
     """Return (is_valid, error_message). Ensures the file actually matches the vendor format."""
     content_lower = content.lower()
-    is_xml = content.strip().startswith("<") or filename.lower().endswith(".xml")
+    is_xml  = content.strip().startswith("<") or filename.lower().endswith(".xml")
+    is_json = content.strip().startswith(("{", "[")) or filename.lower().endswith(".json")
 
     if vendor == "asa":
-        if is_xml:
-            return False, "Cisco configs are text-based, but this file appears to be XML."
+        if is_xml or is_json:
+            return False, "Cisco configs are text-based, but this file appears to be XML or JSON."
         if "access-list" not in content_lower:
             return False, "No Cisco access-list statements found. Check vendor selection."
 
     elif vendor == "paloalto":
         if not is_xml:
-            return False, "Palo Alto Networks configs are XML-based, but this file is not XML."
-        pa_markers = ("<devices>", "<vsys>", "<security>", "<rulebase>")
-        if not any(m in content_lower for m in pa_markers):
+            return False, "Palo Alto configs are XML-based, but this file is not XML."
+        if not any(m in content_lower for m in ("<devices>", "<vsys>", "<security>", "<rulebase>")):
             return False, "This XML does not contain Palo Alto Networks configuration markers."
 
     elif vendor == "fortinet":
-        if is_xml:
-            return False, "Fortinet configs are text-based, but this file appears to be XML."
-        forti_markers = ("config firewall policy", "set srcintf", "set dstintf")
-        if not any(m in content_lower for m in forti_markers):
+        if is_xml or is_json:
+            return False, "Fortinet configs are text-based, but this file appears to be XML or JSON."
+        if not any(m in content_lower for m in ("config firewall policy", "set srcintf", "set dstintf")):
             return False, "No Fortinet firewall policy statements found. Check vendor selection."
 
     elif vendor == "pfsense":
@@ -93,6 +125,14 @@ def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bo
         if "<pfsense>" not in content_lower:
             return False, "pfSense root element <pfsense> not found in this XML file."
 
+    elif vendor == "aws":
+        if not is_json:
+            return False, "AWS Security Group exports are JSON. Please upload a .json file."
+
+    elif vendor == "azure":
+        if not is_json:
+            return False, "Azure NSG exports are JSON. Please upload a .json file."
+
     else:
         return False, f"Unknown vendor: {vendor}"
 
@@ -100,7 +140,6 @@ def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bo
 
 
 def _sort_findings(findings: list) -> list:
-    """Sort findings: base HIGH → base MEDIUM → compliance HIGH → compliance MEDIUM → other."""
     def priority(f):
         is_comp = any(x in f for x in ("PCI-", "CIS-", "NIST-"))
         if "[HIGH]"   in f and not is_comp: return 0
@@ -111,33 +150,26 @@ def _sort_findings(findings: list) -> list:
     return sorted(findings, key=priority)
 
 
-# --- ASA audit helpers (mirrors main.py logic) ---
+# ── ASA audit helpers ─────────────────────────────────────────────────────────
 
 def _check_any_any(parse):
-    findings = []
-    for rule in parse.find_objects(r"access-list.*permit.*any any"):
-        findings.append(f"[HIGH] Overly permissive rule found: {rule.text}")
-    return findings
+    return [f"[HIGH] Overly permissive rule found: {r.text}"
+            for r in parse.find_objects(r"access-list.*permit.*any any")]
 
 
 def _check_missing_logging(parse):
-    findings = []
-    for rule in parse.find_objects(r"access-list.*permit"):
-        if "log" not in rule.text:
-            findings.append(f"[MEDIUM] Permit rule missing logging: {rule.text}")
-    return findings
+    return [f"[MEDIUM] Permit rule missing logging: {r.text}"
+            for r in parse.find_objects(r"access-list.*permit") if "log" not in r.text]
 
 
 def _check_deny_all(parse):
-    deny_rules = parse.find_objects(r"access-list.*deny ip any any")
-    if not deny_rules:
-        return ["[HIGH] No explicit deny-all rule found at end of ACL"]
-    return []
+    return [] if parse.find_objects(r"access-list.*deny ip any any") else [
+        "[HIGH] No explicit deny-all rule found at end of ACL"
+    ]
 
 
 def _check_redundant_rules(parse):
-    findings = []
-    seen = []
+    findings, seen = [], []
     for rule in parse.find_objects(r"access-list.*permit"):
         text_clean = rule.text.strip().lower().replace(" log", "").strip()
         if text_clean in seen:
@@ -149,37 +181,34 @@ def _check_redundant_rules(parse):
 
 def _audit_asa(filepath):
     parse = CiscoConfParse(filepath, ignore_blank_lines=False)
-    findings = []
-    findings += _check_any_any(parse)
-    findings += _check_missing_logging(parse)
-    findings += _check_deny_all(parse)
-    findings += _check_redundant_rules(parse)
+    findings = (
+        _check_any_any(parse)
+        + _check_missing_logging(parse)
+        + _check_deny_all(parse)
+        + _check_redundant_rules(parse)
+    )
     return findings, parse
 
 
 def _build_summary(findings):
-    high = [f for f in findings if "[HIGH]" in f and not any(x in f for x in ["PCI-", "CIS-", "NIST-"])]
+    def _count(tag):
+        return len([f for f in findings if tag in f])
+    high   = [f for f in findings if "[HIGH]"   in f and not any(x in f for x in ["PCI-", "CIS-", "NIST-"])]
     medium = [f for f in findings if "[MEDIUM]" in f and not any(x in f for x in ["PCI-", "CIS-", "NIST-"])]
-    pci_high = [f for f in findings if "PCI-HIGH" in f]
-    pci_medium = [f for f in findings if "PCI-MEDIUM" in f]
-    cis_high = [f for f in findings if "CIS-HIGH" in f]
-    cis_medium = [f for f in findings if "CIS-MEDIUM" in f]
-    nist_high = [f for f in findings if "NIST-HIGH" in f]
-    nist_medium = [f for f in findings if "NIST-MEDIUM" in f]
     return {
-        "high": len(high),
-        "medium": len(medium),
-        "pci_high": len(pci_high),
-        "pci_medium": len(pci_medium),
-        "cis_high": len(cis_high),
-        "cis_medium": len(cis_medium),
-        "nist_high": len(nist_high),
-        "nist_medium": len(nist_medium),
-        "total": len(findings),
+        "high":        len(high),
+        "medium":      len(medium),
+        "pci_high":    _count("PCI-HIGH"),
+        "pci_medium":  _count("PCI-MEDIUM"),
+        "cis_high":    _count("CIS-HIGH"),
+        "cis_medium":  _count("CIS-MEDIUM"),
+        "nist_high":   _count("NIST-HIGH"),
+        "nist_medium": _count("NIST-MEDIUM"),
+        "total":       len(findings),
     }
 
 
-# --- Routes ---
+# ── Routes ────────────────────────────────────────────────────────────────────
 
 @app.route("/")
 def index():
@@ -192,43 +221,39 @@ def run_audit():
     if "config" not in request.files or request.files["config"].filename == "":
         return jsonify({"error": "No config file uploaded"}), 400
 
-    vendor = request.form.get("vendor", "auto").strip().lower()
-    compliance = request.form.get("compliance", "").strip().lower() or None
+    vendor       = request.form.get("vendor", "auto").strip().lower()
+    compliance   = request.form.get("compliance", "").strip().lower() or None
     generate_pdf = request.form.get("report") == "1"
+    archive_it   = request.form.get("archive") == "1"
 
-    # Save upload to temp file first (needed for detection/validation)
     upload = request.files["config"]
     suffix = Path(upload.filename).suffix or ".txt"
     temp_name = f"{uuid.uuid4()}{suffix}"
     temp_path = os.path.join(UPLOAD_FOLDER, temp_name)
     upload.save(temp_path)
 
-    # Read a sample for detection and validation (one read, used for both)
     try:
         with open(temp_path, "r", errors="ignore") as f:
             sample = f.read(16384)
     except Exception:
         sample = ""
 
-    # Auto-detect vendor from file contents
     if vendor == "auto":
         vendor = detect_vendor(sample, upload.filename) or ""
 
-    if vendor not in ("asa", "paloalto", "fortinet", "pfsense"):
+    if vendor not in ALL_VENDORS:
         os.remove(temp_path)
         return jsonify({"error": "Could not determine vendor. Please select one manually."}), 400
 
-    # Validate the file actually matches the chosen vendor's format
     is_valid, validation_msg = validate_vendor_format(sample, upload.filename, vendor)
     if not is_valid:
         os.remove(temp_path)
-        vendor_name = VENDOR_DISPLAY.get(vendor, vendor)
-        return jsonify({"error": f"Wrong vendor selected ({vendor_name}): {validation_msg}"}), 400
+        return jsonify({"error": f"Wrong vendor selected ({VENDOR_DISPLAY.get(vendor, vendor)}): {validation_msg}"}), 400
 
     try:
-        # Run audit
-        findings = []
-        extra_data = None  # for fortinet/pfsense policies/rules
+        findings    = []
+        extra_data  = None
+        parse       = None
 
         if vendor == "asa":
             findings, parse = _audit_asa(temp_path)
@@ -238,43 +263,46 @@ def run_audit():
             findings, extra_data = audit_fortinet(temp_path)
         elif vendor == "pfsense":
             findings, extra_data = audit_pfsense(temp_path)
+        elif vendor == "aws":
+            findings, extra_data = audit_aws_sg(temp_path)
+        elif vendor == "azure":
+            findings, extra_data = audit_azure_nsg(temp_path)
 
-        # Run compliance checks (requires license)
-        compliance_findings = []
+        # Compliance checks (license-gated; not applicable for AWS/Azure)
         license_warning = None
-        if compliance:
-            licensed, lic_msg = check_license()
+        if compliance and vendor not in ("aws", "azure"):
+            licensed, _ = check_license()
             if not licensed:
                 license_warning = (
                     "Compliance checks require a valid license. "
-                    'Purchase one at <a href="https://shamrock13.gumroad.com/l/flintlock" target="_blank" rel="noopener">shamrock13.gumroad.com/l/flintlock</a>. '
-                    "Once purchased, enter your key using the Licensed/Unlicensed badge in the top-right corner of the app."
+                    'Purchase one at <a href="https://shamrock13.gumroad.com/l/flintlock" '
+                    'target="_blank" rel="noopener">shamrock13.gumroad.com/l/flintlock</a>. '
+                    "Once purchased, enter your key using the Licensed/Unlicensed badge in the top-right corner."
                 )
             else:
+                fn_map = {}
                 if vendor == "asa":
                     fn_map = {"cis": check_cis_compliance, "pci": check_pci_compliance, "nist": check_nist_compliance}
                     fn = fn_map.get(compliance)
                     if fn:
-                        compliance_findings = fn(parse)
+                        findings += fn(parse)
                 elif vendor == "paloalto":
                     rules, _ = parse_paloalto(temp_path)
                     fn_map = {"cis": check_cis_compliance_pa, "pci": check_pci_compliance_pa, "nist": check_nist_compliance_pa}
                     fn = fn_map.get(compliance)
                     if fn:
-                        compliance_findings = fn(rules)
+                        findings += fn(rules)
                 elif vendor == "fortinet":
                     fn_map = {"cis": check_cis_compliance_forti, "pci": check_pci_compliance_forti, "nist": check_nist_compliance_forti}
                     fn = fn_map.get(compliance)
                     if fn and extra_data is not None:
-                        compliance_findings = fn(extra_data)
+                        findings += fn(extra_data)
                 elif vendor == "pfsense":
                     fn_map = {"cis": check_cis_compliance_pf, "pci": check_pci_compliance_pf, "nist": check_nist_compliance_pf}
                     fn = fn_map.get(compliance)
                     if fn and extra_data is not None:
-                        compliance_findings = fn(extra_data)
-                findings += compliance_findings
+                        findings += fn(extra_data)
 
-        # Generate PDF report if requested
         report_filename = None
         if generate_pdf:
             report_name = f"flintlock_report_{uuid.uuid4().hex[:8]}.pdf"
@@ -283,14 +311,20 @@ def run_audit():
             report_filename = report_name
 
         findings = _sort_findings(findings)
-        summary = _build_summary(findings)
+        summary  = _build_summary(findings)
+
+        # Optional auto-archive
+        archive_id = None
+        if archive_it:
+            archive_id, _ = save_audit(upload.filename, vendor, findings, summary, config_path=temp_path)
 
         return jsonify({
-            "findings": findings,
-            "summary": summary,
-            "report": report_filename,
+            "findings":        findings,
+            "summary":         summary,
+            "report":          report_filename,
             "license_warning": license_warning,
             "detected_vendor": vendor,
+            "archive_id":      archive_id,
         })
 
     except Exception as e:
@@ -300,9 +334,183 @@ def run_audit():
             os.remove(temp_path)
 
 
+# ── Config diff ───────────────────────────────────────────────────────────────
+
+@app.route("/diff", methods=["POST"])
+def run_diff():
+    if "config_a" not in request.files or "config_b" not in request.files:
+        return jsonify({"error": "Two config files required (config_a and config_b)"}), 400
+    if request.files["config_a"].filename == "" or request.files["config_b"].filename == "":
+        return jsonify({"error": "Both config files must be selected"}), 400
+
+    vendor = request.form.get("vendor", "auto").strip().lower()
+
+    upload_a = request.files["config_a"]
+    upload_b = request.files["config_b"]
+    suffix_a = Path(upload_a.filename).suffix or ".txt"
+    suffix_b = Path(upload_b.filename).suffix or ".txt"
+    path_a = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix_a}")
+    path_b = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix_b}")
+    upload_a.save(path_a)
+    upload_b.save(path_b)
+
+    try:
+        # Auto-detect from the first file if needed
+        if vendor == "auto":
+            with open(path_a, "r", errors="ignore") as f:
+                sample = f.read(16384)
+            vendor = detect_vendor(sample, upload_a.filename) or ""
+
+        if vendor not in ALL_VENDORS:
+            return jsonify({"error": "Could not determine vendor. Please select one manually."}), 400
+
+        if vendor in ("aws", "azure"):
+            return jsonify({"error": "Config diff is not supported for cloud vendors (AWS/Azure). Use the audit tool separately."}), 400
+
+        result = diff_configs(vendor, path_a, path_b)
+        result["vendor"]     = vendor
+        result["filename_a"] = upload_a.filename
+        result["filename_b"] = upload_b.filename
+        return jsonify(result)
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        for p in (path_a, path_b):
+            if os.path.exists(p):
+                os.remove(p)
+
+
+# ── Live SSH connect ──────────────────────────────────────────────────────────
+
+@app.route("/connect", methods=["POST"])
+def live_connect():
+    host       = request.form.get("host", "").strip()
+    port       = request.form.get("port", "22").strip() or "22"
+    username   = request.form.get("username", "").strip()
+    password   = request.form.get("password", "")
+    vendor     = request.form.get("vendor", "").strip().lower()
+    compliance = request.form.get("compliance", "").strip().lower() or None
+
+    if not host or not username or not vendor:
+        return jsonify({"error": "host, username, and vendor are required"}), 400
+    if vendor not in ("asa", "fortinet", "paloalto"):
+        return jsonify({"error": f"Live SSH not supported for vendor '{vendor}'. Supported: asa, fortinet, paloalto"}), 400
+
+    try:
+        from .ssh_connector import connect_and_pull
+        temp_path, _ = connect_and_pull(
+            vendor, host, port, username, password,
+            timeout=30, upload_folder=UPLOAD_FOLDER
+        )
+    except Exception as e:
+        return jsonify({"error": f"Connection failed: {e}"}), 500
+
+    try:
+        findings   = []
+        extra_data = None
+        parse      = None
+
+        if vendor == "asa":
+            findings, parse = _audit_asa(temp_path)
+        elif vendor == "paloalto":
+            findings = audit_paloalto(temp_path)
+        elif vendor == "fortinet":
+            findings, extra_data = audit_fortinet(temp_path)
+
+        if compliance and vendor not in ("aws", "azure"):
+            licensed, _ = check_license()
+            if licensed:
+                if vendor == "asa":
+                    fn_map = {"cis": check_cis_compliance, "pci": check_pci_compliance, "nist": check_nist_compliance}
+                    fn = fn_map.get(compliance)
+                    if fn:
+                        findings += fn(parse)
+                elif vendor == "paloalto":
+                    rules, _ = parse_paloalto(temp_path)
+                    fn_map = {"cis": check_cis_compliance_pa, "pci": check_pci_compliance_pa, "nist": check_nist_compliance_pa}
+                    fn = fn_map.get(compliance)
+                    if fn:
+                        findings += fn(rules)
+                elif vendor == "fortinet":
+                    fn_map = {"cis": check_cis_compliance_forti, "pci": check_pci_compliance_forti, "nist": check_nist_compliance_forti}
+                    fn = fn_map.get(compliance)
+                    if fn and extra_data is not None:
+                        findings += fn(extra_data)
+
+        findings = _sort_findings(findings)
+        summary  = _build_summary(findings)
+
+        label = f"{vendor.upper()}@{host}"
+        archive_id, _ = save_audit(label, vendor, findings, summary, config_path=temp_path)
+
+        return jsonify({
+            "findings":        findings,
+            "summary":         summary,
+            "detected_vendor": vendor,
+            "host":            host,
+            "archive_id":      archive_id,
+        })
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+# ── Archive API ───────────────────────────────────────────────────────────────
+
+@app.route("/archive", methods=["GET"])
+def archive_list():
+    return jsonify(list_archive())
+
+
+@app.route("/archive/save", methods=["POST"])
+def archive_save():
+    """Manually save the most recent audit result to the archive."""
+    data = request.get_json(silent=True) or {}
+    filename = data.get("filename", "unknown")
+    vendor   = data.get("vendor", "unknown")
+    findings = data.get("findings", [])
+    summary  = data.get("summary", {})
+    if not findings and not summary:
+        return jsonify({"error": "No audit data to save"}), 400
+    entry_id, entry = save_audit(filename, vendor, findings, summary)
+    return jsonify({"id": entry_id, "entry": entry})
+
+
+@app.route("/archive/<entry_id>", methods=["GET"])
+def archive_get(entry_id):
+    entry = get_entry(entry_id)
+    if not entry:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(entry)
+
+
+@app.route("/archive/<entry_id>", methods=["DELETE"])
+def archive_delete(entry_id):
+    deleted = delete_entry(entry_id)
+    return jsonify({"deleted": deleted})
+
+
+@app.route("/archive/compare", methods=["POST"])
+def archive_compare():
+    data = request.get_json(silent=True) or {}
+    id_a = data.get("id_a", "")
+    id_b = data.get("id_b", "")
+    if not id_a or not id_b:
+        return jsonify({"error": "id_a and id_b are required"}), 400
+    result, error = compare_entries(id_a, id_b)
+    if error:
+        return jsonify({"error": error}), 404
+    return jsonify(result)
+
+
+# ── Reports / License ─────────────────────────────────────────────────────────
+
 @app.route("/reports/<filename>")
 def download_report(filename):
-    # Safety: only allow safe filenames with no path traversal
     if ".." in filename or "/" in filename:
         return "Not found", 404
     path = os.path.join(REPORTS_FOLDER, filename)

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -22,7 +22,7 @@ from .diff import diff_configs
 from .archive import save_audit, list_archive, get_entry, delete_entry, compare_entries
 from .activity_log import (
     log_activity, list_activity, delete_activity_entry, clear_activity,
-    ACTION_FILE_AUDIT, ACTION_SSH_CONNECT, ACTION_CONFIG_DIFF, ACTION_COMPARISON,
+    ACTION_FILE_AUDIT, ACTION_SSH_CONNECT, ACTION_CONFIG_DIFF,
 )
 
 UPLOAD_FOLDER    = os.environ.get("UPLOAD_FOLDER",    "/tmp/flintlock_uploads")


### PR DESCRIPTION
## Summary

- **Rule change diff** — Upload two configs of the same vendor to see added, removed, and unchanged rules side-by-side (`diff.py`, `/diff` endpoint, Compare Configs tab)
- **Live SSH connection** — Connect to Cisco ASA, Fortinet, or Palo Alto via SSH to pull and audit the running config in real time (`ssh_connector.py`, `/connect` endpoint, Live Connect tab)
- **AWS Security Group support** — Parse and audit `aws ec2 describe-security-groups` JSON exports (`aws.py`)
- **Azure NSG support** — Parse and audit `az network nsg show` JSON exports (`azure.py`)
- **Fortinet v2 checks** — Four new enhanced checks: disabled policies, all-service rules, insecure services (Telnet/HTTP/FTP), and unnamed policies
- **Archival reviews** — Persist audit results and compare any two historical audits with delta scores, resolved/new findings (`archive.py`, `/archive/*` endpoints, Audit History tab)

## Changes

- New modules: `diff.py`, `ssh_connector.py`, `aws.py`, `azure.py`, `archive.py`
- `web.py`: Routes `/diff`, `/connect`, `/archive`, `/archive/save`, `/archive/<id>`, `/archive/compare`
- `index.html`: Refactored to four-tab layout — File Audit | Compare Configs | Live Connect | Audit History
- `style.css`: New styles for tabs, diff rows, history list, comparison delta view
- `requirements.txt`: Added `paramiko>=3.0` for live SSH

## Test plan

- [ ] File Audit tab: upload existing test configs (`tests/test_asa.txt`, `test_forti.txt`, `test_pa.xml`, `test_pfsense.xml`) and verify findings render correctly
- [ ] Compare Configs tab: upload two slightly different versions of a config and verify added/removed/unchanged sections are colour-coded
- [ ] AWS: upload a JSON file from `aws ec2 describe-security-groups` and verify port-open findings appear
- [ ] Azure: upload a JSON file from `az network nsg show` and verify inbound-any findings appear
- [ ] Fortinet v2: upload a FortiGate config with a disabled policy and unnamed policy; verify new finding categories appear
- [ ] Audit History: run an audit with "Save to Audit History" checked, navigate to History tab and confirm the entry appears; select two entries and run a comparison
- [ ] Live Connect tab: verify SSH connection errors surface cleanly when credentials are wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)