### PR TITLE
Update README for v1.1 and fix ruff E701 in web.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 
 | Vendor | Config Format | Status |
 |---|---|---|
-| Cisco ASA | Text | ✅ Supported |
-| Palo Alto Networks | XML | ✅ Supported |
-| Fortinet | Text | ✅ Supported |
-| pfSense | XML | ✅ Supported |
 | AWS Security Groups | JSON | ✅ Supported |
 | Azure NSG | JSON | ✅ Supported |
+| Cisco | Text | ✅ Supported |
+| Fortinet | Text | ✅ Supported |
+| Palo Alto Networks | XML | ✅ Supported |
+| pfSense | XML | ✅ Supported |
 
 ---
 
@@ -25,22 +25,28 @@
 ### Free (Open Source)
 - **Web UI** — browser-based interface, no terminal required
 - **Auto-detect vendor** — Flintlock identifies the vendor from file content automatically
-- **Live SSH connection** — connect directly to a Cisco ASA, Fortinet, or Palo Alto device to pull and audit its running config in real time
+- **Security scoring** — each audit produces a 0–100 score: `100 − (HIGH × 10) − (MEDIUM × 3)`
+- **Category badges** — findings are tagged by type (Exposure, Protocol, Logging, Hygiene, Redundancy)
+- **Remediation guidance** — every finding includes a plain-English fix recommendation
+- **Device tag system** — name your devices (e.g. ASA01, FortiGate-HQ) for auto-versioned history tracking
+- **Live SSH connection** — connect directly to a Cisco, Fortinet, or Palo Alto device to pull and audit its running config in real time
 - **Rule change diff** — upload two configs of the same vendor to see exactly what was added, removed, and unchanged
-- **Audit History** — save audit results and browse them later with vendor filter, sort, and filename search
+- **Audit History** — save audit results and browse them later with vendor filter, sort, and device search
+- **Score Trends chart** — visualize security score over time per device, with vendor and device tag filters
 - **Archival reviews** — select any two saved audits and compare them: see resolved findings, new issues, and delta scores
 - **Activity Log** — full record of every audit, SSH attempt, and config diff, including failures
 - Detect overly permissive any/any rules
 - Detect permit rules missing logging
 - Detect missing deny-all rule
 - Detect redundant/shadowed rules
-- Fortinet enhanced checks: disabled policies, all-service rules, insecure services (Telnet/HTTP/FTP), unnamed policies
-- AWS: open ingress to 0.0.0.0/0, unrestricted port ranges
-- Azure: inbound Any rules, overly permissive NSG rules
-- Severity scoring (HIGH / MEDIUM)
-- Clickable severity filters on results
-- **PDF report export** — download a color-coded findings report
-- Light and dark mode (preference saved automatically)
+- Cisco: Telnet management enabled, unrestricted ICMP permit rules
+- Palo Alto: any-application rules, rules missing security profiles, rules missing descriptions
+- Fortinet: disabled policies, all-service rules, insecure services (Telnet/HTTP/FTP), unnamed policies, internet-facing policies missing UTM profiles
+- pfSense: WAN-facing any-source pass rules, rules missing descriptions
+- AWS: open ingress to 0.0.0.0/0, default SG with active rules, wide port ranges (>100 ports)
+- Azure: inbound Any rules, overly permissive NSG rules, broad port ranges (>100 ports)
+- **PDF report export** — color-coded findings report with score box, category labels, and remediation text
+- Light / dark / auto theme (saved automatically)
 - CLI output with audit summary
 - Docker Compose deployment
 
@@ -111,26 +117,29 @@ PYTHONPATH=src python -m flintlock.main --file config.txt --vendor asa
 The web interface provides the full feature set without needing a terminal. It is organized into five tabs.
 
 ### File Audit
-1. Upload a firewall config file (text, XML, or JSON)
-2. Select a vendor or leave on **Auto-detect**
-3. Optionally select a compliance framework (license required)
-4. Check **Generate PDF Report** and/or **Save to Audit History** as needed
-5. Click **Run Audit**
+1. Enter a **Device Tag** to name this device (e.g. ASA01, FortiGate-HQ) — used for versioned history and trend tracking
+2. Upload a firewall config file (text, XML, or JSON)
+3. Select a vendor or leave on **Auto-detect**
+4. Optionally select a compliance framework (license required)
+5. Check **Generate PDF Report** and/or **Save to Audit History** as needed
+6. Click **Run Audit**
 
-Results are sorted high → medium. Click the summary boxes to filter by severity.
+Results show a security score, severity counts, category-tagged findings, and remediation guidance. Click the summary boxes to filter by severity.
 
 ### Compare Configs
 Upload two configs of the same vendor to see a line-by-line diff of what changed — rules added, removed, and unchanged. Auto-detects vendor from the baseline file.
 
 ### Live Connect
-Connect directly to a device over SSH to pull and audit its running configuration without touching a file. Supported vendors: **Cisco ASA**, **Fortinet**, **Palo Alto Networks**.
+Connect directly to a device over SSH to pull and audit its running configuration without touching a file. Supported vendors: **Cisco**, **Fortinet**, **Palo Alto Networks**.
 
 - Credentials are used only for the single connection and are never stored
 - Successful audits are automatically saved to Audit History
 - Failed connections are recorded in the Activity Log only
 
 ### Audit History
-Browse all saved audits. Filter by vendor, sort by date or issue count, and search by filename. Select any two entries and click **Compare Selected** to see a full diff of findings between the two audits — including resolved issues, new issues, and HIGH/MEDIUM/Total deltas. The older audit is always used as the baseline regardless of selection order.
+Browse all saved audits. Filter by vendor, sort by date or issue count, and search by device tag or filename. Select any two entries and click **Compare Selected** to see a full diff of findings — including resolved issues, new issues, and HIGH/MEDIUM/Total deltas. The older audit is always used as the baseline regardless of selection order.
+
+The **Score Trends** chart below the history list plots each device's security score over time. Filter by vendor and device tag to focus on a specific device.
 
 ### Activity Log
 A complete record of every action taken in Flintlock — file audits, SSH connections, and config diffs — including failures. Shows action type, vendor, timestamp, and error message for failed attempts. Entries can be deleted individually or cleared in bulk.
@@ -207,6 +216,7 @@ Medium Severity:       2
 PCI Compliance High:   2
 PCI Compliance Medium: 1
 Total Issues:          7
+Score:                 54/100
 ---------------------
 
 📄 Report saved to: report.pdf
@@ -222,12 +232,20 @@ Total Issues:          7
 | Missing deny-all rule | HIGH | Cisco, Palo Alto, pfSense | Free |
 | Permit rules missing logging | MEDIUM | Cisco, Palo Alto | Free |
 | Redundant/shadowed rules | MEDIUM | All | Free |
+| Telnet management enabled | MEDIUM | Cisco | Free |
+| Unrestricted ICMP permit | MEDIUM | Cisco | Free |
+| Any-application rules | HIGH | Palo Alto | Free |
+| Rules missing security profile | MEDIUM | Palo Alto | Free |
+| Rules missing description | MEDIUM | Palo Alto, pfSense | Free |
 | Disabled policies | MEDIUM | Fortinet | Free |
 | All-service rules | MEDIUM | Fortinet | Free |
-| Insecure services allowed (Telnet/HTTP/FTP) | MEDIUM | Fortinet | Free |
+| Insecure services (Telnet/HTTP/FTP) | MEDIUM | Fortinet | Free |
 | Unnamed policies | MEDIUM | Fortinet | Free |
+| Internet-facing policy missing UTM | HIGH | Fortinet | Free |
+| WAN-facing any-source pass rule | HIGH | pfSense | Free |
 | Open ingress 0.0.0.0/0 | HIGH | AWS | Free |
-| Unrestricted port ranges | MEDIUM | AWS | Free |
+| Default SG with active rules | MEDIUM | AWS | Free |
+| Wide port range (>100 ports) | MEDIUM | AWS, Azure | Free |
 | Inbound Any rules | HIGH | Azure | Free |
 | Overly permissive NSG rules | MEDIUM | Azure | Free |
 | PDF report export | — | All | Free |
@@ -243,18 +261,23 @@ Total Issues:          7
 - [x] Docker Compose deployment
 - [x] Auto vendor detection
 - [x] Clickable severity filters
-- [x] Light / dark mode
-- [x] PDF report redesign
-- [x] Live SSH/API connection mode
+- [x] Light / dark / auto theme
+- [x] PDF report redesign (score box, categories, remediation)
+- [x] Live SSH connection mode
 - [x] Fortinet v2 checks
 - [x] AWS Security Group support
 - [x] Azure NSG support
 - [x] Rule change diff (compare two configs)
 - [x] Activity Log (usage monitoring)
-- [x] Archival reviews (compare historical configs)
-- [ ] Archival review trends & scoring graphs
+- [x] Archival reviews (compare historical audits)
+- [x] Security scoring (0–100 per audit)
+- [x] Category badges and remediation guidance
+- [x] Score Trends chart with device tag and vendor filters
+- [x] Device tag system with auto-versioning
+- [ ] Settings tab (global defaults)
 - [ ] Scheduled audits
 - [ ] Multi-device bulk audit
+- [ ] Cisco FTD (NGFW) support
 
 ---
 

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -146,10 +146,14 @@ def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bo
 def _sort_findings(findings: list) -> list:
     def priority(f):
         is_comp = any(x in f for x in ("PCI-", "CIS-", "NIST-"))
-        if "[HIGH]"   in f and not is_comp: return 0
-        if "[MEDIUM]" in f and not is_comp: return 1
-        if "HIGH"     in f and is_comp:     return 2
-        if "MEDIUM"   in f and is_comp:     return 3
+        if "[HIGH]"   in f and not is_comp:
+            return 0
+        if "[MEDIUM]" in f and not is_comp:
+            return 1
+        if "HIGH"     in f and is_comp:
+            return 2
+        if "MEDIUM"   in f and is_comp:
+            return 3
         return 4
     return sorted(findings, key=priority)
 


### PR DESCRIPTION
## Summary
- README: scoring, device tags, Score Trends, all new checks documented, vendors alphabetized, "Cisco ASA" → "Cisco"
- web.py: expand single-line if/return statements in `_sort_findings` to satisfy ruff E701

🤖 Generated with [Claude Code](https://claude.com/claude-code)