### PR TITLE
Add FTD support, bulk audit, scheduling, HIPAA compliance, nav overhaul, and hostname extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "ciscoconfparse>=1.9",
     "fpdf2>=2.7",
     "flask>=3.0",
+    "paramiko>=3.0",
+    "apscheduler>=3.10",
 ]
 
 [tool.poetry]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ciscoconfparse>=1.9
 fpdf2>=2.7
 flask>=3.0
 paramiko>=3.0
+apscheduler>=3.10

--- a/src/flintlock/audit_engine.py
+++ b/src/flintlock/audit_engine.py
@@ -1,0 +1,258 @@
+"""Shared audit engine utilities used by both web.py and scheduler_runner.py.
+
+Extracts the vendor-dispatch logic and finding helpers so they can be
+imported without creating circular dependencies.
+"""
+from ciscoconfparse import CiscoConfParse
+
+
+# ── Finding helpers ────────────────────────────────────────────────────────────
+
+def _f(severity, category, message, remediation=""):
+    return {"severity": severity, "category": category, "message": message, "remediation": remediation}
+
+
+def _finding_msg(f):
+    return f["message"] if isinstance(f, dict) else f
+
+
+def _findings_to_strings(findings):
+    return [_finding_msg(f) for f in findings]
+
+
+def _wrap_compliance(s):
+    if isinstance(s, dict):
+        return s
+    sev = "HIGH" if any(x in s for x in ("-HIGH", "[HIGH]")) else "MEDIUM"
+    return {"severity": sev, "category": "compliance", "message": s, "remediation": None}
+
+
+def _sort_findings(findings: list) -> list:
+    def priority(f):
+        msg = _finding_msg(f)
+        is_comp = any(x in msg for x in ("PCI-", "CIS-", "NIST-", "HIPAA-"))
+        if "[HIGH]"   in msg and not is_comp:
+            return 0
+        if "[MEDIUM]" in msg and not is_comp:
+            return 1
+        if "HIGH"     in msg and is_comp:
+            return 2
+        if "MEDIUM"   in msg and is_comp:
+            return 3
+        return 4
+    return sorted(findings, key=priority)
+
+
+def _build_summary(findings):
+    def _count(tag):
+        return len([f for f in findings if tag in _finding_msg(f)])
+    high   = [f for f in findings if "[HIGH]"   in _finding_msg(f) and not any(x in _finding_msg(f) for x in ["PCI-", "CIS-", "NIST-", "HIPAA-"])]
+    medium = [f for f in findings if "[MEDIUM]" in _finding_msg(f) and not any(x in _finding_msg(f) for x in ["PCI-", "CIS-", "NIST-", "HIPAA-"])]
+    score  = max(0, 100 - len(high) * 10 - len(medium) * 3)
+    return {
+        "high":          len(high),
+        "medium":        len(medium),
+        "pci_high":      _count("PCI-HIGH"),
+        "pci_medium":    _count("PCI-MEDIUM"),
+        "cis_high":      _count("CIS-HIGH"),
+        "cis_medium":    _count("CIS-MEDIUM"),
+        "nist_high":     _count("NIST-HIGH"),
+        "nist_medium":   _count("NIST-MEDIUM"),
+        "hipaa_high":    _count("HIPAA-HIGH"),
+        "hipaa_medium":  _count("HIPAA-MEDIUM"),
+        "total":         len(findings),
+        "score":         score,
+    }
+
+
+# ── ASA audit helpers ──────────────────────────────────────────────────────────
+
+def _check_any_any(parse):
+    return [
+        _f("HIGH", "exposure",
+           f"[HIGH] Overly permissive rule found: {r.text.strip()}",
+           "Restrict source and destination to specific IP ranges. "
+           "Remove or scope down any/any permit rules to enforce least-privilege access.")
+        for r in parse.find_objects(r"access-list.*permit.*any any")
+    ]
+
+
+def _check_missing_logging(parse):
+    return [
+        _f("MEDIUM", "logging",
+           f"[MEDIUM] Permit rule missing logging: {r.text.strip()}",
+           "Add the 'log' keyword to all permit rules. "
+           "Without logging, permitted traffic produces no syslog entries for monitoring.")
+        for r in parse.find_objects(r"access-list.*permit") if "log" not in r.text
+    ]
+
+
+def _check_deny_all(parse):
+    if parse.find_objects(r"access-list.*deny ip any any"):
+        return []
+    return [_f(
+        "HIGH", "hygiene",
+        "[HIGH] No explicit deny-all rule found at end of ACL",
+        "Add an explicit 'access-list <name> deny ip any any log' at the end of each ACL. "
+        "Relying on implicit deny produces no log entries and is not auditable."
+    )]
+
+
+def _check_redundant_rules(parse):
+    findings, seen = [], []
+    for rule in parse.find_objects(r"access-list.*permit"):
+        text_clean = rule.text.strip().lower().replace(" log", "").strip()
+        if text_clean in seen:
+            findings.append(_f(
+                "MEDIUM", "redundancy",
+                f"[MEDIUM] Redundant rule detected: {rule.text.strip()}",
+                "Remove duplicate ACL entries to keep the access-list clean and auditable. "
+                "Redundant rules indicate configuration drift and complicate change management."
+            ))
+        else:
+            seen.append(text_clean)
+    return findings
+
+
+def _check_telnet_asa(parse):
+    return [
+        _f("MEDIUM", "protocol",
+           f"[MEDIUM] Telnet management access configured: {r.text.strip()}",
+           "Disable Telnet management (no telnet ...) and enforce SSH. "
+           "Telnet transmits all data including credentials in cleartext.")
+        for r in parse.find_objects(r"^telnet\s")
+    ]
+
+
+def _check_icmp_any_asa(parse):
+    return [
+        _f("MEDIUM", "exposure",
+           f"[MEDIUM] Unrestricted ICMP permit rule: {r.text.strip()}",
+           "Restrict ICMP to specific source ranges or permit only echo-reply, "
+           "unreachable, and time-exceeded message types needed for diagnostics.")
+        for r in parse.find_objects(r"access-list.*permit icmp any any")
+    ]
+
+
+def _audit_asa(filepath):
+    parse = CiscoConfParse(filepath, ignore_blank_lines=False)
+    findings = (
+        _check_any_any(parse)
+        + _check_missing_logging(parse)
+        + _check_deny_all(parse)
+        + _check_redundant_rules(parse)
+        + _check_telnet_asa(parse)
+        + _check_icmp_any_asa(parse)
+    )
+    return findings, parse
+
+
+# ── Vendor dispatch ────────────────────────────────────────────────────────────
+
+def run_vendor_audit(vendor: str, temp_path: str):
+    """
+    Run the appropriate auditor for the given vendor.
+    Returns (findings, parse_obj_or_None, extra_data_or_None).
+    parse_obj is set for ASA/FTD (CiscoConfParse).
+    extra_data is set for Fortinet/pfSense (list of policy dicts).
+    """
+    from .ftd import audit_ftd
+    from .paloalto import audit_paloalto
+    from .fortinet import audit_fortinet
+    from .pfsense import audit_pfsense
+    from .aws import audit_aws_sg
+    from .azure import audit_azure_nsg
+
+    if vendor == "ftd":
+        findings, parse = audit_ftd(temp_path)
+        return findings, parse, None
+    if vendor == "asa":
+        findings, parse = _audit_asa(temp_path)
+        return findings, parse, None
+    if vendor == "paloalto":
+        findings, rules = audit_paloalto(temp_path)
+        return findings, None, rules  # rules returned as extra_data for compliance reuse
+    if vendor == "fortinet":
+        findings, extra_data = audit_fortinet(temp_path)
+        return findings, None, extra_data
+    if vendor == "pfsense":
+        findings, extra_data = audit_pfsense(temp_path)
+        return findings, None, extra_data
+    if vendor == "aws":
+        findings, extra_data = audit_aws_sg(temp_path)
+        return findings, None, extra_data
+    if vendor == "azure":
+        findings, extra_data = audit_azure_nsg(temp_path)
+        return findings, None, extra_data
+    raise ValueError(f"Unknown vendor: {vendor}")
+
+
+def run_compliance_checks(vendor: str, compliance: str, parse, extra_data, temp_path: str = "") -> list:
+    """Run compliance checks for the given vendor and framework. Returns raw finding strings.
+
+    For paloalto, extra_data should be the rules list returned by run_vendor_audit — the file
+    is NOT re-parsed here, eliminating the double-parse that would otherwise occur.
+    """
+    from .compliance import (
+        check_cis_compliance, check_pci_compliance, check_nist_compliance,
+        check_hipaa_compliance,
+        check_cis_compliance_ftd, check_pci_compliance_ftd, check_nist_compliance_ftd,
+        check_hipaa_compliance_ftd,
+        check_cis_compliance_pa, check_pci_compliance_pa, check_nist_compliance_pa,
+        check_hipaa_compliance_pa,
+        check_cis_compliance_forti, check_pci_compliance_forti, check_nist_compliance_forti,
+        check_hipaa_compliance_forti,
+        check_cis_compliance_pf, check_pci_compliance_pf, check_nist_compliance_pf,
+        check_hipaa_compliance_pf,
+    )
+
+    if vendor in ("aws", "azure"):
+        return []
+
+    fn_map: dict = {}
+
+    if vendor == "asa":
+        fn_map = {
+            "cis":   (check_cis_compliance,   parse),
+            "pci":   (check_pci_compliance,   parse),
+            "nist":  (check_nist_compliance,  parse),
+            "hipaa": (check_hipaa_compliance, parse),
+        }
+    elif vendor == "ftd":
+        fn_map = {
+            "cis":   (check_cis_compliance_ftd,   parse),
+            "pci":   (check_pci_compliance_ftd,   parse),
+            "nist":  (check_nist_compliance_ftd,  parse),
+            "hipaa": (check_hipaa_compliance_ftd, parse),
+        }
+    elif vendor == "paloalto":
+        # extra_data is the rules list already parsed by run_vendor_audit — no re-parse needed
+        rules = extra_data or []
+        fn_map = {
+            "cis":   (check_cis_compliance_pa,   rules),
+            "pci":   (check_pci_compliance_pa,   rules),
+            "nist":  (check_nist_compliance_pa,  rules),
+            "hipaa": (check_hipaa_compliance_pa, rules),
+        }
+    elif vendor == "fortinet":
+        fn_map = {
+            "cis":   (check_cis_compliance_forti,   extra_data),
+            "pci":   (check_pci_compliance_forti,   extra_data),
+            "nist":  (check_nist_compliance_forti,  extra_data),
+            "hipaa": (check_hipaa_compliance_forti, extra_data),
+        }
+    elif vendor == "pfsense":
+        fn_map = {
+            "cis":   (check_cis_compliance_pf,   extra_data),
+            "pci":   (check_pci_compliance_pf,   extra_data),
+            "nist":  (check_nist_compliance_pf,  extra_data),
+            "hipaa": (check_hipaa_compliance_pf, extra_data),
+        }
+
+    entry = fn_map.get(compliance)
+    if not entry:
+        return []
+    fn, arg = entry
+    if arg is None:
+        return []
+    return fn(arg)

--- a/src/flintlock/compliance.py
+++ b/src/flintlock/compliance.py
@@ -1,132 +1,504 @@
+"""Compliance framework checks — CIS, PCI-DSS, NIST SP 800-41, HIPAA Security Rule.
+
+Each check function returns a list of finding strings tagged with the framework
+prefix (CIS-HIGH, PCI-MEDIUM, NIST-HIGH, HIPAA-HIGH, etc.).
+
+Vendors covered: Cisco ASA, Cisco FTD, Palo Alto, Fortinet, pfSense.
+"""
+
+# ══════════════════════════════════════════════════════════════ CISCO ASA ══
+
+
 def check_cis_compliance(parse):
+    """CIS Cisco ASA Firewall Benchmark checks."""
     findings = []
 
-    # CIS ASA Benchmark checks
+    # CIS 1 — Explicit deny-all at end of ACL
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append("[CIS-HIGH] CIS Control 1: No default deny-all rule found")
 
-    # 1. Ensure default deny exists
-    deny_rules = parse.find_objects(r"access-list.*deny ip any any")
-    if not deny_rules:
-        findings.append("[CIS-HIGH] CIS Control: No default deny-all rule found")
-
-    # 2. Ensure no any/any permit rules exist
+    # CIS 2 — No any/any permit rules (least privilege)
     any_any = parse.find_objects(r"access-list.*permit.*any any")
     if any_any:
-        findings.append(f"[CIS-HIGH] CIS Control: {len(any_any)} any/any permit rule(s) violate least privilege")
+        findings.append(
+            f"[CIS-HIGH] CIS Control 2: {len(any_any)} any/any permit rule(s) violate least privilege"
+        )
 
-    # 3. Ensure all permit rules have logging
+    # CIS 3 — All permit rules must have logging
     for rule in parse.find_objects(r"access-list.*permit"):
         if "log" not in rule.text:
-            findings.append(f"[CIS-MEDIUM] CIS Control: Permit rule missing logging: {rule.text}")
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 3: Permit rule missing logging: {rule.text.strip()}"
+            )
+
+    # CIS 4 — SSH must be locked to version 2
+    if parse.find_objects(r"^ssh version 1"):
+        findings.append("[CIS-HIGH] CIS Control 4: SSHv1 is enabled — disable it and enforce SSHv2 only")
+    elif not parse.find_objects(r"^ssh version 2"):
+        findings.append("[CIS-MEDIUM] CIS Control 4: SSH version not explicitly locked to version 2")
+
+    # CIS 5 — SNMPv1/v2c community strings must not be used
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[CIS-HIGH] CIS Control 5: SNMPv1/v2c community string in use: {r.text.strip()} — migrate to SNMPv3"
+        )
+
+    # CIS 6 — Telnet management access must be disabled
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[CIS-HIGH] CIS Control 6: Telnet management access is configured — disable and use SSH"
+        )
+
+    # CIS 7 — HTTP/ASDM server should be disabled or restricted
+    if parse.find_objects(r"^http server enable"):
+        if not parse.find_objects(r"^http\s+\d"):
+            findings.append(
+                "[CIS-MEDIUM] CIS Control 7: HTTP/ASDM server enabled with no host restriction"
+            )
+
+    # CIS 8 — NTP server must be configured
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 8: No NTP server configured — accurate timestamps are required for log integrity"
+        )
+
+    # CIS 9 — Login banner must be set
+    if not parse.find_objects(r"^banner (login|motd|exec)"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 9: No login banner configured — banners provide legal notice and deter unauthorized access"
+        )
+
+    # CIS 10 — Password encryption must be enabled
+    if not parse.find_objects(r"^password encryption aes") and not parse.find_objects(r"^service password-encryption"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 10: Password encryption not configured — enable 'service password-encryption' or AES encryption"
+        )
+
+    # CIS 11 — Unrestricted ICMP from any source
+    if parse.find_objects(r"access-list.*permit icmp any any"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 11: Unrestricted ICMP (any/any) permitted — restrict ICMP to necessary types and sources"
+        )
 
     return findings
 
 
 def check_pci_compliance(parse):
+    """PCI-DSS Requirement checks for Cisco ASA."""
     findings = []
 
-    # PCI-DSS Requirement 1 checks
-
-    # 1. No any/any rules (PCI Req 1.3)
+    # PCI Req 1.3 — No any/any rules (direct routes to cardholder data prohibited)
     any_any = parse.find_objects(r"access-list.*permit.*any any")
     if any_any:
-        findings.append(f"[PCI-HIGH] PCI Req 1.3: {len(any_any)} any/any rule(s) found - direct routes to cardholder data prohibited")
+        findings.append(
+            f"[PCI-HIGH] PCI Req 1.3: {len(any_any)} any/any rule(s) found — direct routes to cardholder data prohibited"
+        )
 
-    # 2. All permit rules must log (PCI Req 10.2)
+    # PCI Req 10.2 — All permit rules must log (audit trail)
     for rule in parse.find_objects(r"access-list.*permit"):
         if "log" not in rule.text:
-            findings.append(f"[PCI-MEDIUM] PCI Req 10.2: Permit rule missing logging: {rule.text}")
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 10.2: Permit rule missing logging: {rule.text.strip()}"
+            )
 
-    # 3. Explicit deny all must exist (PCI Req 1.2)
-    deny_rules = parse.find_objects(r"access-list.*deny ip any any")
-    if not deny_rules:
+    # PCI Req 1.2 — Explicit deny all must exist
+    if not parse.find_objects(r"access-list.*deny ip any any"):
         findings.append("[PCI-HIGH] PCI Req 1.2: No explicit deny-all rule found")
+
+    # PCI Req 2.2.3 — Insecure protocols (Telnet) must be disabled
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[PCI-HIGH] PCI Req 2.2.3: Telnet management access configured — Telnet is an insecure protocol prohibited by PCI-DSS"
+        )
+
+    # PCI Req 2.2 — SNMPv1/v2c must not be used
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[PCI-HIGH] PCI Req 2.2: SNMPv1/v2c community string in use: {r.text.strip()} — PCI-DSS requires SNMPv3"
+        )
+
+    # PCI Req 10.5 — Syslog server must be configured (log protection)
+    if not parse.find_objects(r"^logging host"):
+        findings.append(
+            "[PCI-HIGH] PCI Req 10.5: No remote syslog server configured — logs must be sent to a protected central log server"
+        )
+
+    # PCI Req 6.4 — NTP required for accurate audit timestamps
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[PCI-MEDIUM] PCI Req 10.4: No NTP server configured — synchronized time is required for accurate audit log timestamps"
+        )
+
+    # PCI Req 2.2 — HTTP/ASDM server exposure
+    if parse.find_objects(r"^http server enable") and not parse.find_objects(r"^http\s+\d"):
+        findings.append(
+            "[PCI-MEDIUM] PCI Req 2.2: HTTP/ASDM server enabled with no host restriction — restrict to authorized management hosts"
+        )
+
+    # PCI Req 1.1 — Unrestricted ICMP
+    if parse.find_objects(r"access-list.*permit icmp any any"):
+        findings.append(
+            "[PCI-MEDIUM] PCI Req 1.1: Unrestricted ICMP (any/any) permitted — restrict to necessary types to limit network exposure"
+        )
 
     return findings
 
 
 def check_nist_compliance(parse):
+    """NIST SP 800-41 / NIST 800-53 checks for Cisco ASA."""
     findings = []
 
-    # NIST SP 800-41 checks
-
-    # 1. Least privilege - no any/any
+    # NIST AC-6 — Least privilege: no any/any
     any_any = parse.find_objects(r"access-list.*permit.*any any")
     if any_any:
-        findings.append(f"[NIST-HIGH] NIST AC-6: {len(any_any)} any/any rule(s) violate least privilege principle")
+        findings.append(
+            f"[NIST-HIGH] NIST AC-6: {len(any_any)} any/any permit rule(s) violate least privilege principle"
+        )
 
-    # 2. Audit trail - logging required
+    # NIST AU-2 — Audit events: logging required on permit rules
     for rule in parse.find_objects(r"access-list.*permit"):
         if "log" not in rule.text:
-            findings.append(f"[NIST-MEDIUM] NIST AU-2: Permit rule missing audit logging: {rule.text}")
+            findings.append(
+                f"[NIST-MEDIUM] NIST AU-2: Permit rule missing audit logging: {rule.text.strip()}"
+            )
 
-    # 3. Boundary protection - deny all must exist
-    deny_rules = parse.find_objects(r"access-list.*deny ip any any")
-    if not deny_rules:
+    # NIST SC-7 — Boundary protection: deny-all must exist
+    if not parse.find_objects(r"access-list.*deny ip any any"):
         findings.append("[NIST-HIGH] NIST SC-7: No boundary protection deny-all rule found")
+
+    # NIST SC-8 — Transmission confidentiality: no Telnet
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[NIST-HIGH] NIST SC-8: Telnet configured — NIST SC-8 requires encrypted management channels; use SSH"
+        )
+
+    # NIST AU-9 — Log protection: remote syslog required
+    if not parse.find_objects(r"^logging host"):
+        findings.append(
+            "[NIST-HIGH] NIST AU-9: No remote syslog server configured — logs must be protected from local modification or loss"
+        )
+
+    # NIST IA-3 — Device authentication: SNMPv3 required
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[NIST-HIGH] NIST IA-3: SNMPv1/v2c community string in use — NIST requires authenticated SNMPv3: {r.text.strip()}"
+        )
+
+    # NIST CM-7 — Least functionality: SSH version lock
+    if parse.find_objects(r"^ssh version 1"):
+        findings.append(
+            "[NIST-HIGH] NIST CM-7: SSHv1 is enabled — disable to enforce least functionality"
+        )
+    elif not parse.find_objects(r"^ssh version 2"):
+        findings.append(
+            "[NIST-MEDIUM] NIST CM-7: SSH version not locked to version 2 — enforce SSHv2 to reduce attack surface"
+        )
+
+    # NIST AU-8 — Time stamps: NTP required
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[NIST-MEDIUM] NIST AU-8: No NTP server configured — accurate time synchronization is required for reliable audit timestamps"
+        )
+
+    # NIST AC-17 — Remote access: HTTP/ASDM exposure
+    if parse.find_objects(r"^http server enable") and not parse.find_objects(r"^http\s+\d"):
+        findings.append(
+            "[NIST-MEDIUM] NIST AC-17: HTTP/ASDM management server unrestricted — limit remote access to authorized management hosts"
+        )
 
     return findings
 
 
-def check_cis_compliance_pa(rules):
+# ══════════════════════════════════════════════════════════ CISCO FTD ══
+
+
+def check_cis_compliance_ftd(parse):
+    """CIS checks for Cisco FTD (LINA CLI config)."""
     findings = []
 
-    # CIS 1 - No any/any permit
+    # CIS 1 — Explicit deny-all
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append("[CIS-HIGH] CIS Control 1: No default deny-all ACL rule found")
+
+    # CIS 2 — No any/any permit
+    any_any = parse.find_objects(r"access-list.*permit.*any any")
+    if any_any:
+        findings.append(
+            f"[CIS-HIGH] CIS Control 2: {len(any_any)} any/any permit rule(s) violate least privilege"
+        )
+
+    # CIS 3 — All permit rules must log
+    for rule in parse.find_objects(r"access-list.*permit"):
+        if "log" not in rule.text:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 3: Permit rule missing logging: {rule.text.strip()}"
+            )
+
+    # CIS 4 — Threat detection must be enabled
+    if not parse.find_objects(r"^threat-detection"):
+        findings.append(
+            "[CIS-HIGH] CIS Control 4: Threat detection not configured — enable threat-detection basic-threat"
+        )
+
+    # CIS 5 — Intrusion policy (IPS/Snort) must be referenced
+    if not parse.find_objects(r"^intrusion-policy") and not parse.find_objects(r"snort"):
+        findings.append(
+            "[CIS-HIGH] CIS Control 5: No intrusion prevention policy reference found — assign an IPS policy in FMC"
+        )
+
+    # CIS 6 — SSH version 2 only
+    if parse.find_objects(r"^ssh version 1"):
+        findings.append("[CIS-HIGH] CIS Control 6: SSHv1 is enabled — enforce SSHv2 only")
+    elif not parse.find_objects(r"^ssh version 2"):
+        findings.append("[CIS-MEDIUM] CIS Control 6: SSH version not locked to version 2")
+
+    # CIS 7 — SNMPv1/v2c must not be used
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[CIS-HIGH] CIS Control 7: SNMPv1/v2c community string configured — migrate to SNMPv3: {r.text.strip()}"
+        )
+
+    # CIS 8 — No Telnet
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[CIS-HIGH] CIS Control 8: Telnet management access configured — disable and use SSH"
+        )
+
+    # CIS 9 — NTP configured
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 9: No NTP server configured — accurate timestamps required for FTD event correlation"
+        )
+
+    # CIS 10 — Remote syslog
+    if not parse.find_objects(r"^logging host"):
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 10: No remote syslog server configured"
+        )
+
+    return findings
+
+
+def check_pci_compliance_ftd(parse):
+    """PCI-DSS checks for Cisco FTD."""
+    findings = []
+
+    # PCI 1.3 — No any/any
+    any_any = parse.find_objects(r"access-list.*permit.*any any")
+    if any_any:
+        findings.append(
+            f"[PCI-HIGH] PCI Req 1.3: {len(any_any)} any/any rule(s) — direct routes to cardholder data prohibited"
+        )
+
+    # PCI 10.2 — Logging on permit rules
+    for rule in parse.find_objects(r"access-list.*permit"):
+        if "log" not in rule.text:
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 10.2: Permit rule missing logging: {rule.text.strip()}"
+            )
+
+    # PCI 1.2 — Explicit deny all
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append("[PCI-HIGH] PCI Req 1.2: No explicit deny-all rule found")
+
+    # PCI 2.2.3 — Telnet prohibited
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[PCI-HIGH] PCI Req 2.2.3: Telnet management configured — prohibited by PCI-DSS"
+        )
+
+    # PCI 10.5 — Remote syslog
+    if not parse.find_objects(r"^logging host"):
+        findings.append(
+            "[PCI-HIGH] PCI Req 10.5: No remote syslog server — logs must be sent to a protected central server"
+        )
+
+    # PCI 2.2 — SNMP
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[PCI-HIGH] PCI Req 2.2: SNMPv1/v2c in use: {r.text.strip()} — PCI-DSS requires SNMPv3"
+        )
+
+    # PCI 6.4 — IPS must be deployed
+    if not parse.find_objects(r"^intrusion-policy") and not parse.find_objects(r"snort"):
+        findings.append(
+            "[PCI-HIGH] PCI Req 6.6: No intrusion prevention policy found — IPS is required to detect and block web-based attacks"
+        )
+
+    # PCI 10.4 — NTP for audit timestamps
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[PCI-MEDIUM] PCI Req 10.4: No NTP server configured — synchronized time required for audit log integrity"
+        )
+
+    return findings
+
+
+def check_nist_compliance_ftd(parse):
+    """NIST SP 800-41 / NIST 800-53 checks for Cisco FTD."""
+    findings = []
+
+    # NIST AC-6 — Least privilege
+    any_any = parse.find_objects(r"access-list.*permit.*any any")
+    if any_any:
+        findings.append(
+            f"[NIST-HIGH] NIST AC-6: {len(any_any)} any/any rule(s) violate least privilege"
+        )
+
+    # NIST AU-2 — Audit logging
+    for rule in parse.find_objects(r"access-list.*permit"):
+        if "log" not in rule.text:
+            findings.append(
+                f"[NIST-MEDIUM] NIST AU-2: Permit rule missing audit logging: {rule.text.strip()}"
+            )
+
+    # NIST SC-7 — Boundary protection
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append("[NIST-HIGH] NIST SC-7: No boundary protection deny-all rule found")
+
+    # NIST SC-8 — No Telnet
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[NIST-HIGH] NIST SC-8: Telnet configured — use encrypted SSH management per NIST SC-8"
+        )
+
+    # NIST SI-3 — IPS/malware protection
+    if not parse.find_objects(r"^intrusion-policy") and not parse.find_objects(r"snort"):
+        findings.append(
+            "[NIST-HIGH] NIST SI-3: No intrusion prevention policy found — NIST SI-3 requires malicious code protection"
+        )
+
+    # NIST AU-9 — Log protection via remote syslog
+    if not parse.find_objects(r"^logging host"):
+        findings.append(
+            "[NIST-HIGH] NIST AU-9: No remote syslog server — audit records must be protected from local loss or tampering"
+        )
+
+    # NIST IA-3 — SNMPv3 for device authentication
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            f"[NIST-HIGH] NIST IA-3: SNMPv1/v2c in use — NIST requires authenticated SNMPv3: {r.text.strip()}"
+        )
+
+    # NIST AU-8 — NTP
+    if not parse.find_objects(r"^ntp server"):
+        findings.append(
+            "[NIST-MEDIUM] NIST AU-8: No NTP server — accurate timestamps required for audit records"
+        )
+
+    return findings
+
+
+# ════════════════════════════════════════════════════════ PALO ALTO ══
+
+
+def check_cis_compliance_pa(rules):
+    """CIS Palo Alto Networks Firewall Benchmark checks."""
+    findings = []
+
     for rule in rules:
         name = rule.get("name", "unnamed")
         src = [s.text for s in rule.findall(".//source/member")]
         dst = [d.text for d in rule.findall(".//destination/member")]
         action = rule.findtext(".//action")
-        if action == "allow" and "any" in src and "any" in dst:
-            findings.append(f"[CIS-HIGH] CIS Control: Rule '{name}' violates least privilege - any/any permit")
-
-    # CIS 2 - All permit rules must log
-    for rule in rules:
-        name = rule.get("name", "unnamed")
-        action = rule.findtext(".//action")
         log_end = rule.findtext(".//log-end")
         log_start = rule.findtext(".//log-start")
-        if action == "allow" and log_end != "yes" and log_start != "yes":
-            findings.append(f"[CIS-MEDIUM] CIS Control: Rule '{name}' missing logging")
+        apps = [a.text for a in rule.findall(".//application/member")]
+        profile_setting = rule.find(".//profile-setting")
 
-    # CIS 3 - Deny all must exist
+        # CIS 1 — No any/any permit
+        if action == "allow" and "any" in src and "any" in dst:
+            findings.append(
+                f"[CIS-HIGH] CIS Control 1: Rule '{name}' violates least privilege — any/any permit"
+            )
+
+        # CIS 2 — All permit rules must log
+        if action == "allow" and log_end != "yes" and log_start != "yes":
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 2: Rule '{name}' missing logging"
+            )
+
+        # CIS 3 — Security profiles must be attached to allow rules
+        if action == "allow":
+            has_profile = profile_setting is not None and (
+                profile_setting.find(".//profiles") is not None
+                or profile_setting.find(".//group") is not None
+            )
+            if not has_profile:
+                findings.append(
+                    f"[CIS-MEDIUM] CIS Control 3: Rule '{name}' has no security profile attached — "
+                    "attach an AV, IPS, and URL filtering profile to inspect allowed traffic"
+                )
+
+        # CIS 4 — Application 'any' in allow rules
+        if action == "allow" and "any" in apps:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 4: Rule '{name}' permits any application — "
+                "specify allowed applications to enforce application-based policy"
+            )
+
+    # CIS 5 — Deny all must exist
     has_deny_all = any(
-        rule.findtext(".//action") == "deny" and
-        "any" in [s.text for s in rule.findall(".//source/member")] and
-        "any" in [d.text for d in rule.findall(".//destination/member")]
+        rule.findtext(".//action") == "deny"
+        and "any" in [s.text for s in rule.findall(".//source/member")]
+        and "any" in [d.text for d in rule.findall(".//destination/member")]
         for rule in rules
     )
     if not has_deny_all:
-        findings.append("[CIS-HIGH] CIS Control: No default deny-all rule found")
+        findings.append("[CIS-HIGH] CIS Control 5: No default deny-all rule found")
+
+    # CIS 6 — Unnamed rules
+    unnamed = [r for r in rules if not r.get("name") or r.get("name", "").lower() in ("unnamed", "")]
+    if unnamed:
+        findings.append(
+            f"[CIS-MEDIUM] CIS Control 6: {len(unnamed)} unnamed rule(s) found — all rules must be named for audit clarity"
+        )
 
     return findings
 
 
 def check_pci_compliance_pa(rules):
+    """PCI-DSS checks for Palo Alto Networks."""
     findings = []
 
-    # PCI Req 1.3 - No any/any
     for rule in rules:
         name = rule.get("name", "unnamed")
         src = [s.text for s in rule.findall(".//source/member")]
         dst = [d.text for d in rule.findall(".//destination/member")]
         action = rule.findtext(".//action")
-        if action == "allow" and "any" in src and "any" in dst:
-            findings.append(f"[PCI-HIGH] PCI Req 1.3: Rule '{name}' - direct routes to cardholder data prohibited")
-
-    # PCI Req 10.2 - Logging required
-    for rule in rules:
-        name = rule.get("name", "unnamed")
-        action = rule.findtext(".//action")
         log_end = rule.findtext(".//log-end")
         log_start = rule.findtext(".//log-start")
-        if action == "allow" and log_end != "yes" and log_start != "yes":
-            findings.append(f"[PCI-MEDIUM] PCI Req 10.2: Rule '{name}' missing audit logging")
+        profile_setting = rule.find(".//profile-setting")
 
-    # PCI Req 1.2 - Explicit deny all
+        # PCI 1.3 — No any/any
+        if action == "allow" and "any" in src and "any" in dst:
+            findings.append(
+                f"[PCI-HIGH] PCI Req 1.3: Rule '{name}' — direct routes to cardholder data prohibited"
+            )
+
+        # PCI 10.2 — Logging required
+        if action == "allow" and log_end != "yes" and log_start != "yes":
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 10.2: Rule '{name}' missing audit logging"
+            )
+
+        # PCI 6.6 — Security profiles for application inspection
+        if action == "allow":
+            has_profile = profile_setting is not None and (
+                profile_setting.find(".//profiles") is not None
+                or profile_setting.find(".//group") is not None
+            )
+            if not has_profile:
+                findings.append(
+                    f"[PCI-MEDIUM] PCI Req 6.6: Rule '{name}' has no security profile — "
+                    "attach IPS/AV profiles to inspect traffic for cardholder data threats"
+                )
+
+    # PCI 1.2 — Explicit deny all
     has_deny_all = any(
-        rule.findtext(".//action") == "deny" and
-        "any" in [s.text for s in rule.findall(".//source/member")] and
-        "any" in [d.text for d in rule.findall(".//destination/member")]
+        rule.findtext(".//action") == "deny"
+        and "any" in [s.text for s in rule.findall(".//source/member")]
+        and "any" in [d.text for d in rule.findall(".//destination/member")]
         for rule in rules
     )
     if not has_deny_all:
@@ -136,31 +508,55 @@ def check_pci_compliance_pa(rules):
 
 
 def check_nist_compliance_pa(rules):
+    """NIST SP 800-41 / NIST 800-53 checks for Palo Alto Networks."""
     findings = []
 
-    # NIST AC-6 - Least privilege
     for rule in rules:
         name = rule.get("name", "unnamed")
         src = [s.text for s in rule.findall(".//source/member")]
         dst = [d.text for d in rule.findall(".//destination/member")]
         action = rule.findtext(".//action")
-        if action == "allow" and "any" in src and "any" in dst:
-            findings.append(f"[NIST-HIGH] NIST AC-6: Rule '{name}' violates least privilege principle")
-
-    # NIST AU-2 - Audit logging
-    for rule in rules:
-        name = rule.get("name", "unnamed")
-        action = rule.findtext(".//action")
         log_end = rule.findtext(".//log-end")
         log_start = rule.findtext(".//log-start")
-        if action == "allow" and log_end != "yes" and log_start != "yes":
-            findings.append(f"[NIST-MEDIUM] NIST AU-2: Rule '{name}' missing audit logging")
+        apps = [a.text for a in rule.findall(".//application/member")]
+        profile_setting = rule.find(".//profile-setting")
 
-    # NIST SC-7 - Boundary protection
+        # NIST AC-6 — Least privilege
+        if action == "allow" and "any" in src and "any" in dst:
+            findings.append(
+                f"[NIST-HIGH] NIST AC-6: Rule '{name}' violates least privilege principle"
+            )
+
+        # NIST AU-2 — Audit logging
+        if action == "allow" and log_end != "yes" and log_start != "yes":
+            findings.append(
+                f"[NIST-MEDIUM] NIST AU-2: Rule '{name}' missing audit logging"
+            )
+
+        # NIST SI-3 — Security profiles (malicious code protection)
+        if action == "allow":
+            has_profile = profile_setting is not None and (
+                profile_setting.find(".//profiles") is not None
+                or profile_setting.find(".//group") is not None
+            )
+            if not has_profile:
+                findings.append(
+                    f"[NIST-MEDIUM] NIST SI-3: Rule '{name}' has no security profile — "
+                    "attach AV/IPS profiles per NIST SI-3 malicious code protection requirement"
+                )
+
+        # NIST CM-7 — Application 'any' reduces least functionality
+        if action == "allow" and "any" in apps:
+            findings.append(
+                f"[NIST-MEDIUM] NIST CM-7: Rule '{name}' permits any application — "
+                "specify applications to enforce least functionality"
+            )
+
+    # NIST SC-7 — Boundary protection
     has_deny_all = any(
-        rule.findtext(".//action") == "deny" and
-        "any" in [s.text for s in rule.findall(".//source/member")] and
-        "any" in [d.text for d in rule.findall(".//destination/member")]
+        rule.findtext(".//action") == "deny"
+        and "any" in [s.text for s in rule.findall(".//source/member")]
+        and "any" in [d.text for d in rule.findall(".//destination/member")]
         for rule in rules
     )
     if not has_deny_all:
@@ -168,7 +564,12 @@ def check_nist_compliance_pa(rules):
 
     return findings
 
+
+# ══════════════════════════════════════════════════════════ FORTINET ══
+
+
 def check_cis_compliance_forti(policies):
+    """CIS Fortinet FortiGate Benchmark checks."""
     findings = []
 
     for p in policies:
@@ -177,23 +578,62 @@ def check_cis_compliance_forti(policies):
         dst = p.get("dstaddr", [])
         action = p.get("action", "")
         logtraffic = p.get("logtraffic", "")
+        service = p.get("service", [])
+        av_profile = p.get("av-profile", "")
+        ips_sensor = p.get("ips-sensor", "")
+        webfilter_profile = p.get("webfilter-profile", "")
 
+        # CIS 1 — No any/any permit
         if action == "accept" and "all" in src and "all" in dst:
-            findings.append(f"[CIS-HIGH] CIS Control: Rule '{name}' violates least privilege - source/dest all")
-        if action == "accept" and logtraffic not in ["all", "utm"]:
-            findings.append(f"[CIS-MEDIUM] CIS Control: Rule '{name}' missing logging")
+            findings.append(
+                f"[CIS-HIGH] CIS Control 1: Rule '{name}' violates least privilege — source/dest all"
+            )
 
+        # CIS 2 — All permit rules must log
+        if action == "accept" and logtraffic not in ("all", "utm"):
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 2: Rule '{name}' missing logging"
+            )
+
+        # CIS 3 — Service 'ALL' in permit rules
+        if action == "accept" and "ALL" in service:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 3: Rule '{name}' permits all services — restrict to required services only"
+            )
+
+        # CIS 4 — AV profile attached to permit rules
+        if action == "accept" and not av_profile:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 4: Rule '{name}' has no AV profile attached"
+            )
+
+        # CIS 5 — IPS sensor attached to permit rules
+        if action == "accept" and not ips_sensor:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 5: Rule '{name}' has no IPS sensor attached"
+            )
+
+        # CIS 6 — Web filter for internet-facing rules
+        if action == "accept" and not webfilter_profile and "all" in dst:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 6: Rule '{name}' with unrestricted destination has no web filter profile"
+            )
+
+    # CIS 7 — Deny all must exist
     has_deny_all = any(
-        p.get("action") == "deny" and "all" in p.get("srcaddr", []) and "all" in p.get("dstaddr", [])
+        p.get("action") == "deny"
+        and "all" in p.get("srcaddr", [])
+        and "all" in p.get("dstaddr", [])
         for p in policies
     )
     if not has_deny_all:
-        findings.append("[CIS-HIGH] CIS Control: No default deny-all rule found")
+        findings.append("[CIS-HIGH] CIS Control 7: No default deny-all rule found")
 
     return findings
 
 
 def check_pci_compliance_forti(policies):
+    """PCI-DSS checks for Fortinet FortiGate."""
     findings = []
 
     for p in policies:
@@ -202,14 +642,45 @@ def check_pci_compliance_forti(policies):
         dst = p.get("dstaddr", [])
         action = p.get("action", "")
         logtraffic = p.get("logtraffic", "")
+        ips_sensor = p.get("ips-sensor", "")
+        av_profile = p.get("av-profile", "")
+        service = p.get("service", [])
 
+        # PCI 1.3 — No any/any
         if action == "accept" and "all" in src and "all" in dst:
-            findings.append(f"[PCI-HIGH] PCI Req 1.3: Rule '{name}' - direct routes to cardholder data prohibited")
-        if action == "accept" and logtraffic not in ["all", "utm"]:
-            findings.append(f"[PCI-MEDIUM] PCI Req 10.2: Rule '{name}' missing audit logging")
+            findings.append(
+                f"[PCI-HIGH] PCI Req 1.3: Rule '{name}' — direct routes to cardholder data prohibited"
+            )
 
+        # PCI 10.2 — Logging required
+        if action == "accept" and logtraffic not in ("all", "utm"):
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 10.2: Rule '{name}' missing audit logging"
+            )
+
+        # PCI 6.6 — IPS required for allowed traffic
+        if action == "accept" and not ips_sensor:
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 6.6: Rule '{name}' has no IPS sensor — IPS required to detect attacks against cardholder data"
+            )
+
+        # PCI 5.1 — AV required for allowed traffic
+        if action == "accept" and not av_profile:
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 5.1: Rule '{name}' has no AV profile — AV protection required per PCI-DSS Req 5"
+            )
+
+        # PCI 1.1 — Service ALL prohibited
+        if action == "accept" and "ALL" in service:
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 1.1: Rule '{name}' permits all services — define only required and documented services"
+            )
+
+    # PCI 1.2 — Explicit deny all
     has_deny_all = any(
-        p.get("action") == "deny" and "all" in p.get("srcaddr", []) and "all" in p.get("dstaddr", [])
+        p.get("action") == "deny"
+        and "all" in p.get("srcaddr", [])
+        and "all" in p.get("dstaddr", [])
         for p in policies
     )
     if not has_deny_all:
@@ -219,6 +690,7 @@ def check_pci_compliance_forti(policies):
 
 
 def check_nist_compliance_forti(policies):
+    """NIST SP 800-41 / NIST 800-53 checks for Fortinet FortiGate."""
     findings = []
 
     for p in policies:
@@ -227,14 +699,45 @@ def check_nist_compliance_forti(policies):
         dst = p.get("dstaddr", [])
         action = p.get("action", "")
         logtraffic = p.get("logtraffic", "")
+        ips_sensor = p.get("ips-sensor", "")
+        av_profile = p.get("av-profile", "")
+        service = p.get("service", [])
 
+        # NIST AC-6 — Least privilege
         if action == "accept" and "all" in src and "all" in dst:
-            findings.append(f"[NIST-HIGH] NIST AC-6: Rule '{name}' violates least privilege principle")
-        if action == "accept" and logtraffic not in ["all", "utm"]:
-            findings.append(f"[NIST-MEDIUM] NIST AU-2: Rule '{name}' missing audit logging")
+            findings.append(
+                f"[NIST-HIGH] NIST AC-6: Rule '{name}' violates least privilege principle"
+            )
 
+        # NIST AU-2 — Audit logging
+        if action == "accept" and logtraffic not in ("all", "utm"):
+            findings.append(
+                f"[NIST-MEDIUM] NIST AU-2: Rule '{name}' missing audit logging"
+            )
+
+        # NIST SI-3 — Malicious code protection (AV)
+        if action == "accept" and not av_profile:
+            findings.append(
+                f"[NIST-MEDIUM] NIST SI-3: Rule '{name}' has no AV profile — malicious code protection required"
+            )
+
+        # NIST SI-4 — Intrusion detection (IPS)
+        if action == "accept" and not ips_sensor:
+            findings.append(
+                f"[NIST-MEDIUM] NIST SI-4: Rule '{name}' has no IPS sensor — network monitoring and intrusion detection required"
+            )
+
+        # NIST CM-7 — Least functionality: no ALL services
+        if action == "accept" and "ALL" in service:
+            findings.append(
+                f"[NIST-MEDIUM] NIST CM-7: Rule '{name}' permits all services — restrict to required services only"
+            )
+
+    # NIST SC-7 — Boundary protection
     has_deny_all = any(
-        p.get("action") == "deny" and "all" in p.get("srcaddr", []) and "all" in p.get("dstaddr", [])
+        p.get("action") == "deny"
+        and "all" in p.get("srcaddr", [])
+        and "all" in p.get("dstaddr", [])
         for p in policies
     )
     if not has_deny_all:
@@ -242,34 +745,79 @@ def check_nist_compliance_forti(policies):
 
     return findings
 
+
+# ══════════════════════════════════════════════════════════ PFSENSE ══
+
+
 def check_cis_compliance_pf(rules):
+    """CIS pfSense Firewall Benchmark checks."""
     findings = []
 
     for r in rules:
-        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
-            findings.append(f"[CIS-HIGH] CIS Control: Rule '{r['descr']}' violates least privilege - any/any")
-        if r["type"] == "pass" and not r["log"]:
-            findings.append(f"[CIS-MEDIUM] CIS Control: Rule '{r['descr']}' missing logging")
+        iface = r.get("interface", "unknown")
 
+        # CIS 1 — No any/any permit
+        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
+            findings.append(
+                f"[CIS-HIGH] CIS Control 1: Rule '{r['descr']}' violates least privilege — any/any on {iface}"
+            )
+
+        # CIS 2 — All permit rules must log
+        if r["type"] == "pass" and not r["log"]:
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 2: Rule '{r['descr']}' missing logging"
+            )
+
+        # CIS 3 — Protocol 'any' in permit rules
+        if r["type"] == "pass" and r.get("protocol") in ("any", "", None):
+            findings.append(
+                f"[CIS-MEDIUM] CIS Control 3: Rule '{r['descr']}' permits any protocol — restrict to required protocols"
+            )
+
+    # CIS 4 — Deny all must exist
     has_deny_all = any(
         r["type"] == "block" and r["source"] == "1" and r["destination"] == "1"
         for r in rules
     )
     if not has_deny_all:
-        findings.append("[CIS-HIGH] CIS Control: No default deny-all rule found")
+        findings.append("[CIS-HIGH] CIS Control 4: No default deny-all rule found")
+
+    # CIS 5 — Block rules must exist (defense in depth)
+    block_rules = [r for r in rules if r["type"] == "block"]
+    if not block_rules:
+        findings.append(
+            "[CIS-MEDIUM] CIS Control 5: No explicit block rules found — rely on explicit deny rather than implicit default"
+        )
 
     return findings
 
 
 def check_pci_compliance_pf(rules):
+    """PCI-DSS checks for pfSense."""
     findings = []
 
     for r in rules:
-        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
-            findings.append(f"[PCI-HIGH] PCI Req 1.3: Rule '{r['descr']}' - direct routes to cardholder data prohibited")
-        if r["type"] == "pass" and not r["log"]:
-            findings.append(f"[PCI-MEDIUM] PCI Req 10.2: Rule '{r['descr']}' missing audit logging")
+        iface = r.get("interface", "unknown")
 
+        # PCI 1.3 — No any/any
+        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
+            findings.append(
+                f"[PCI-HIGH] PCI Req 1.3: Rule '{r['descr']}' — direct routes to cardholder data prohibited (any/any on {iface})"
+            )
+
+        # PCI 10.2 — Logging required
+        if r["type"] == "pass" and not r["log"]:
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 10.2: Rule '{r['descr']}' missing audit logging"
+            )
+
+        # PCI 1.1 — Protocol 'any' in permit rules
+        if r["type"] == "pass" and r.get("protocol") in ("any", "", None):
+            findings.append(
+                f"[PCI-MEDIUM] PCI Req 1.1: Rule '{r['descr']}' permits any protocol — document and restrict all allowed services"
+            )
+
+    # PCI 1.2 — Explicit deny all
     has_deny_all = any(
         r["type"] == "block" and r["source"] == "1" and r["destination"] == "1"
         for r in rules
@@ -281,19 +829,287 @@ def check_pci_compliance_pf(rules):
 
 
 def check_nist_compliance_pf(rules):
+    """NIST SP 800-41 / NIST 800-53 checks for pfSense."""
     findings = []
 
     for r in rules:
-        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
-            findings.append(f"[NIST-HIGH] NIST AC-6: Rule '{r['descr']}' violates least privilege principle")
-        if r["type"] == "pass" and not r["log"]:
-            findings.append(f"[NIST-MEDIUM] NIST AU-2: Rule '{r['descr']}' missing audit logging")
+        iface = r.get("interface", "unknown")
 
+        # NIST AC-6 — Least privilege
+        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
+            findings.append(
+                f"[NIST-HIGH] NIST AC-6: Rule '{r['descr']}' violates least privilege (any/any on {iface})"
+            )
+
+        # NIST AU-2 — Audit logging
+        if r["type"] == "pass" and not r["log"]:
+            findings.append(
+                f"[NIST-MEDIUM] NIST AU-2: Rule '{r['descr']}' missing audit logging"
+            )
+
+        # NIST CM-7 — Least functionality: no protocol 'any'
+        if r["type"] == "pass" and r.get("protocol") in ("any", "", None):
+            findings.append(
+                f"[NIST-MEDIUM] NIST CM-7: Rule '{r['descr']}' permits any protocol — restrict to required protocols (least functionality)"
+            )
+
+    # NIST SC-7 — Boundary protection
     has_deny_all = any(
         r["type"] == "block" and r["source"] == "1" and r["destination"] == "1"
         for r in rules
     )
     if not has_deny_all:
         findings.append("[NIST-HIGH] NIST SC-7: No boundary protection deny-all rule found")
+
+    return findings
+
+
+# ══════════════════════════════════════════════════════════ HIPAA COMPLIANCE ══
+
+
+def check_hipaa_compliance(parse):
+    """HIPAA Security Rule checks for Cisco ASA.
+
+    Maps to 45 CFR Part 164, Subpart C (Security Standards).
+    """
+    findings = []
+
+    # §164.312(a)(1) — Access control: no any/any permit
+    any_any = parse.find_objects(r"access-list.*permit.*any any")
+    if any_any:
+        findings.append(
+            f"[HIPAA-HIGH] HIPAA §164.312(a)(1): {len(any_any)} any/any permit rule(s) violate access control"
+        )
+
+    # §164.312(b) — Audit controls: all permit rules must log
+    for rule in parse.find_objects(r"access-list.*permit"):
+        if "log" not in rule.text:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(b): Permit rule missing audit logging: {rule.text.strip()}"
+            )
+
+    # §164.308(a)(1)(ii)(A) — Risk analysis: no explicit deny-all
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(1)(ii)(A): No explicit deny-all rule — boundary risk not addressed"
+        )
+
+    # §164.312(e)(1) — Transmission security: Telnet in use
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.312(e)(1): Telnet transmits ePHI in cleartext — disable and enforce SSH"
+        )
+
+    # §164.312(e)(1) — Transmission security: SSHv1
+    if parse.find_objects(r"^ssh version 1"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.312(e)(1): SSHv1 in use — weak encryption threatens ePHI transmission security"
+        )
+
+    # §164.308(a)(5)(ii)(B) — Malware protection: HTTP server enabled
+    if parse.find_objects(r"^http server enable"):
+        findings.append(
+            "[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): HTTP management server enabled — use HTTPS only to protect ePHI"
+        )
+
+    # §164.308(a)(4) — Information access management: SNMPv1/v2c
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(4): SNMPv1/v2c in use — cleartext SNMP can expose ePHI network data; migrate to SNMPv3"
+        )
+
+    # §164.312(a)(2)(i) — Unique user identification: no login banner
+    if not parse.find_objects(r"^banner (login|motd)"):
+        findings.append(
+            "[HIPAA-MEDIUM] HIPAA §164.312(a)(2)(i): No login banner — required for authorized-use notice and user accountability"
+        )
+
+    return findings
+
+
+def check_hipaa_compliance_ftd(parse):
+    """HIPAA Security Rule checks for Cisco FTD (LINA CLI)."""
+    findings = []
+
+    # §164.312(a)(1) — Access control: any/any permit
+    any_any = parse.find_objects(r"access-list.*permit.*any any")
+    if any_any:
+        findings.append(
+            f"[HIPAA-HIGH] HIPAA §164.312(a)(1): {len(any_any)} any/any permit rule(s) violate access control"
+        )
+
+    # §164.312(b) — Audit controls: logging
+    for rule in parse.find_objects(r"access-list.*permit"):
+        if "log" not in rule.text:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(b): Permit rule missing audit logging: {rule.text.strip()}"
+            )
+
+    # §164.308(a)(1)(ii)(A) — Risk analysis: deny-all
+    if not parse.find_objects(r"access-list.*deny ip any any"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(1)(ii)(A): No explicit deny-all rule — boundary risk not mitigated"
+        )
+
+    # §164.312(e)(1) — Transmission security: Telnet
+    if parse.find_objects(r"^telnet\s"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.312(e)(1): Telnet configured — ePHI transmission in cleartext"
+        )
+
+    # §164.308(a)(5)(ii)(B) — Malware / threat detection
+    if not parse.find_objects(r"^threat-detection basic-threat"):
+        findings.append(
+            "[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): Threat detection not enabled — enable basic threat detection to protect ePHI systems"
+        )
+
+    # §164.308(a)(5)(ii)(B) — IPS / Snort inspection
+    if not parse.find_objects(r"^access-control-policy"):
+        findings.append(
+            "[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): No access-control-policy — IPS/Snort inspection may not be active"
+        )
+
+    # §164.308(a)(4) — Information access management: SNMPv1/v2c
+    for r in parse.find_objects(r"^snmp-server community"):
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(4): SNMPv1/v2c community string detected — migrate to SNMPv3 to protect ePHI network data"
+        )
+
+    return findings
+
+
+def check_hipaa_compliance_pa(rules):
+    """HIPAA Security Rule checks for Palo Alto Networks."""
+    findings = []
+
+    for rule in rules:
+        name = rule.get("name", "unnamed")
+        src  = rule.get("from", [])
+        dst  = rule.get("to", [])
+        act  = rule.get("action", "")
+        log  = rule.get("log-end", "no")
+
+        # §164.312(a)(1) — Access control: any/any permit
+        if act == "allow" and "any" in src and "any" in dst:
+            findings.append(
+                f"[HIPAA-HIGH] HIPAA §164.312(a)(1): Rule '{name}' permits any-to-any — violates access control"
+            )
+
+        # §164.312(b) — Audit controls: log-end
+        if act == "allow" and log != "yes":
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(b): Rule '{name}' missing session-end logging — audit trail incomplete"
+            )
+
+        # §164.308(a)(5)(ii)(B) — Malware: security profiles
+        profiles = rule.get("profile-setting", {})
+        has_profiles = bool(profiles.get("profiles") or profiles.get("group"))
+        if act == "allow" and not has_profiles:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): Rule '{name}' has no security profile — AV/IPS protection for ePHI not applied"
+            )
+
+    # §164.308(a)(1)(ii)(A) — Risk analysis: no deny-all
+    has_deny_all = any(
+        r.get("action") == "deny" and "any" in r.get("from", []) and "any" in r.get("to", [])
+        for r in rules
+    )
+    if not has_deny_all:
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(1)(ii)(A): No explicit deny-all rule — boundary risk not addressed"
+        )
+
+    return findings
+
+
+def check_hipaa_compliance_forti(policies):
+    """HIPAA Security Rule checks for Fortinet FortiGate."""
+    findings = []
+
+    for p in policies:
+        name    = p.get("name", f"policy-{p.get('policyid', '?')}")
+        srcaddr = p.get("srcaddr", [])
+        dstaddr = p.get("dstaddr", [])
+        action  = p.get("action", "")
+        logtr   = p.get("logtraffic", "disable")
+        av      = p.get("av-profile", "")
+        ips     = p.get("ips-sensor", "")
+
+        # §164.312(a)(1) — Access control: any/any permit
+        if action == "accept" and "all" in srcaddr and "all" in dstaddr:
+            findings.append(
+                f"[HIPAA-HIGH] HIPAA §164.312(a)(1): Policy '{name}' allows all-to-all — violates access control"
+            )
+
+        # §164.312(b) — Audit controls: logging
+        if action == "accept" and logtr == "disable":
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(b): Policy '{name}' has logging disabled — no audit trail for ePHI traffic"
+            )
+
+        # §164.308(a)(5)(ii)(B) — Malware: AV profile
+        if action == "accept" and not av:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): Policy '{name}' has no AV profile — malware protection for ePHI missing"
+            )
+
+        # §164.308(a)(5)(ii)(B) — IPS sensor
+        if action == "accept" and not ips:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.308(a)(5)(ii)(B): Policy '{name}' has no IPS sensor — intrusion protection for ePHI missing"
+            )
+
+        # §164.312(e)(1) — Transmission security: service ALL
+        service = p.get("service", [])
+        if action == "accept" and "ALL" in service:
+            findings.append(
+                f"[HIPAA-HIGH] HIPAA §164.312(e)(1): Policy '{name}' permits ALL services — restrict to required services to protect ePHI"
+            )
+
+    # §164.308(a)(1)(ii)(A) — Risk analysis: disabled policies accumulate risk
+    disabled = [p for p in policies if p.get("status") == "disable"]
+    if disabled:
+        findings.append(
+            f"[HIPAA-MEDIUM] HIPAA §164.308(a)(1)(ii)(A): {len(disabled)} disabled policy/policies not reviewed — stale rules increase ePHI risk"
+        )
+
+    return findings
+
+
+def check_hipaa_compliance_pf(rules):
+    """HIPAA Security Rule checks for pfSense."""
+    findings = []
+
+    for r in rules:
+        iface = r.get("interface", "unknown")
+        descr = r.get("descr", "unnamed")
+
+        # §164.312(a)(1) — Access control: any/any pass
+        if r["type"] == "pass" and r["source"] == "1" and r["destination"] == "1":
+            findings.append(
+                f"[HIPAA-HIGH] HIPAA §164.312(a)(1): Rule '{descr}' on {iface} allows any/any — violates access control"
+            )
+
+        # §164.312(b) — Audit controls: logging
+        if r["type"] == "pass" and not r["log"]:
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(b): Rule '{descr}' on {iface} missing logging — audit trail incomplete"
+            )
+
+        # §164.312(e)(1) — Transmission security: protocol any
+        if r["type"] == "pass" and r.get("protocol") in ("any", "", None):
+            findings.append(
+                f"[HIPAA-MEDIUM] HIPAA §164.312(e)(1): Rule '{descr}' on {iface} permits any protocol — restrict to required protocols"
+            )
+
+    # §164.308(a)(1)(ii)(A) — Risk analysis: no explicit block-all
+    has_deny_all = any(
+        r["type"] == "block" and r["source"] == "1" and r["destination"] == "1"
+        for r in rules
+    )
+    if not has_deny_all:
+        findings.append(
+            "[HIPAA-HIGH] HIPAA §164.308(a)(1)(ii)(A): No explicit deny-all rule — boundary protection risk not addressed"
+        )
 
     return findings

--- a/src/flintlock/diff.py
+++ b/src/flintlock/diff.py
@@ -213,11 +213,18 @@ def diff_azure(path_a, path_b):
     return {"added": added, "removed": removed, "unchanged": unchanged}
 
 
+# ── Cisco FTD ─────────────────────────────────────────────────────────────────
+# FTD LINA CLI uses the same access-list syntax as ASA, so we reuse diff_asa.
+
+def diff_ftd(path_a, path_b):
+    return diff_asa(path_a, path_b)
+
+
 # ── Main entrypoint ───────────────────────────────────────────────────────────
 
 def diff_configs(vendor, path_a, path_b):
     """Compare two configs of the same vendor. Returns {added, removed, unchanged}."""
-    if vendor == "asa":
+    if vendor in ("asa", "ftd"):
         return diff_asa(path_a, path_b)
     if vendor == "fortinet":
         return diff_fortinet(path_a, path_b)

--- a/src/flintlock/ftd.py
+++ b/src/flintlock/ftd.py
@@ -1,0 +1,247 @@
+"""Cisco FTD (Firepower Threat Defense) parser and auditor.
+
+Supports FTD LINA CLI output (show running-config) which shares ASA syntax
+but includes FTD-specific commands such as access-control-policy, threat-detection,
+and intrusion-policy references.
+"""
+import re
+from ciscoconfparse import CiscoConfParse
+
+
+def _f(severity, category, message, remediation=""):
+    return {"severity": severity, "category": category, "message": message, "remediation": remediation}
+
+
+# ── Detection ─────────────────────────────────────────────────────────────────
+
+FTD_MARKERS = (
+    "access-control-policy",
+    "firepower threat defense",
+    "firepower-module",
+    "intrusion-policy",
+    "snort",
+)
+
+
+def is_ftd_config(content: str) -> bool:
+    """Return True if the config content contains FTD-specific markers."""
+    lower = content.lower()
+    return any(m in lower for m in FTD_MARKERS)
+
+
+# ── Parser ────────────────────────────────────────────────────────────────────
+
+def parse_ftd(filepath):
+    """Parse an FTD running config using CiscoConfParse (LINA/ASA-compatible CLI)."""
+    return CiscoConfParse(filepath, ignore_blank_lines=False)
+
+
+# ── Individual checks ─────────────────────────────────────────────────────────
+
+def _check_access_control_policy(parse):
+    """Warn if no access-control-policy reference is present (NGFW enforcement)."""
+    if not parse.find_objects(r"^access-control-policy"):
+        return [_f(
+            "MEDIUM", "hygiene",
+            "[MEDIUM] No access-control-policy reference found in config",
+            "Ensure a Firepower access control policy is applied to this FTD device. "
+            "Without an explicit policy, traffic handling falls back to the default action "
+            "which may permit all traffic.",
+        )]
+    return []
+
+
+def _check_threat_detection(parse):
+    """Verify threat-detection is enabled."""
+    if not parse.find_objects(r"^threat-detection"):
+        return [_f(
+            "HIGH", "exposure",
+            "[HIGH] Threat detection is not enabled",
+            "Enable threat detection: 'threat-detection basic-threat' and "
+            "'threat-detection statistics'. Threat detection identifies and blocks "
+            "scanning, DoS, and brute-force attempts in real time.",
+        )]
+    return []
+
+
+def _check_intrusion_policy(parse):
+    """Check that an intrusion/Snort policy is referenced."""
+    has_ips = (
+        parse.find_objects(r"^intrusion-policy")
+        or parse.find_objects(r"snort")
+    )
+    if not has_ips:
+        return [_f(
+            "HIGH", "exposure",
+            "[HIGH] No intrusion prevention policy (IPS/Snort) reference detected",
+            "Assign a Firepower intrusion policy to traffic flows in the access control "
+            "policy. IPS/Snort is a core FTD NGFW capability — without it, Layer-7 "
+            "threats are not inspected.",
+        )]
+    return []
+
+
+def _check_ssl_inspection(parse):
+    """Flag absence of SSL/TLS decryption configuration."""
+    if not parse.find_objects(r"^ssl"):
+        return [_f(
+            "MEDIUM", "exposure",
+            "[MEDIUM] No SSL/TLS decryption policy configured",
+            "Configure SSL inspection to decrypt and inspect encrypted traffic. "
+            "Without decryption, threats concealed in HTTPS, SMTPS, and other "
+            "TLS-wrapped sessions bypass all content inspection.",
+        )]
+    return []
+
+
+def _check_any_any(parse):
+    return [
+        _f("HIGH", "exposure",
+           f"[HIGH] Overly permissive rule found: {r.text.strip()}",
+           "Restrict source and destination to specific IP ranges. "
+           "Remove or scope down any/any permit rules to enforce least-privilege access.")
+        for r in parse.find_objects(r"access-list.*permit.*any any")
+    ]
+
+
+def _check_missing_logging(parse):
+    return [
+        _f("MEDIUM", "logging",
+           f"[MEDIUM] Permit rule missing logging: {r.text.strip()}",
+           "Add the 'log' keyword to all permit rules. Without logging, permitted "
+           "traffic generates no syslog entries and cannot be correlated in a SIEM.")
+        for r in parse.find_objects(r"access-list.*permit") if "log" not in r.text
+    ]
+
+
+def _check_deny_all(parse):
+    if parse.find_objects(r"access-list.*deny ip any any"):
+        return []
+    return [_f(
+        "HIGH", "hygiene",
+        "[HIGH] No explicit deny-all rule found at end of ACL",
+        "Add 'access-list <name> deny ip any any log' as the last entry in each ACL. "
+        "Implicit deny produces no log entries and cannot be verified during audits.",
+    )]
+
+
+def _check_telnet(parse):
+    return [
+        _f("MEDIUM", "protocol",
+           f"[MEDIUM] Telnet management access configured: {r.text.strip()}",
+           "Disable Telnet (no telnet ...) and enforce SSH for all management access. "
+           "Telnet transmits credentials and session data in cleartext.")
+        for r in parse.find_objects(r"^telnet\s")
+    ]
+
+
+def _check_snmp_community(parse):
+    """Flag SNMPv1/v2c community strings; SNMPv3 auth+priv is required."""
+    return [
+        _f("HIGH", "protocol",
+           f"[HIGH] SNMPv1/v2c community string in use: {r.text.strip()}",
+           "Migrate to SNMPv3 with authentication and encryption (authPriv). "
+           "SNMPv1/v2c transmit community strings in cleartext and lack per-user auth.")
+        for r in parse.find_objects(r"^snmp-server community")
+    ]
+
+
+def _check_syslog_server(parse):
+    """Require at least one remote syslog host."""
+    if not parse.find_objects(r"^logging host"):
+        return [_f(
+            "MEDIUM", "logging",
+            "[MEDIUM] No remote syslog server configured",
+            "Configure 'logging host <interface> <ip>' to forward logs to a SIEM or "
+            "syslog aggregator. Local-only logging is lost on reboot and cannot be "
+            "correlated across devices.",
+        )]
+    return []
+
+
+def _check_ssh_version(parse):
+    """Require SSHv2; flag if SSHv1 or no SSH version lock is set."""
+    v2 = parse.find_objects(r"^ssh version 2")
+    v1 = parse.find_objects(r"^ssh version 1")
+    if v1:
+        return [_f(
+            "HIGH", "protocol",
+            "[HIGH] SSHv1 is enabled for management access",
+            "Set 'ssh version 2' and remove any 'ssh version 1' statements. "
+            "SSHv1 has known cryptographic weaknesses and should not be used.",
+        )]
+    if not v2:
+        return [_f(
+            "MEDIUM", "protocol",
+            "[MEDIUM] SSH version not explicitly locked to SSHv2",
+            "Add 'ssh version 2' to prevent fallback to SSHv1. "
+            "Explicit version locking ensures only strong SSH cipher suites are offered.",
+        )]
+    return []
+
+
+def _check_http_server(parse):
+    """Flag HTTP server (ASDM) enabled without restriction."""
+    enabled = parse.find_objects(r"^http server enable")
+    if enabled:
+        # Check if access is restricted to specific hosts
+        restricted = parse.find_objects(r"^http\s+\d")
+        if not restricted:
+            return [_f(
+                "MEDIUM", "exposure",
+                "[MEDIUM] HTTP/ASDM server enabled with no host restriction",
+                "Either disable the HTTP server ('no http server enable') if ASDM is not "
+                "needed, or restrict access with 'http <network> <mask> <interface>' "
+                "to limit management to trusted hosts only.",
+            )]
+    return []
+
+
+def _check_redundant_rules(parse):
+    findings, seen = [], []
+    for rule in parse.find_objects(r"access-list.*permit"):
+        text_clean = re.sub(r"\s+", " ", rule.text.strip().lower().replace(" log", "")).strip()
+        if text_clean in seen:
+            findings.append(_f(
+                "MEDIUM", "redundancy",
+                f"[MEDIUM] Redundant rule detected: {rule.text.strip()}",
+                "Remove duplicate ACL entries. Redundant rules cause configuration drift "
+                "and complicate change management audits.",
+            ))
+        else:
+            seen.append(text_clean)
+    return findings
+
+
+def _check_icmp_any(parse):
+    return [
+        _f("MEDIUM", "exposure",
+           f"[MEDIUM] Unrestricted ICMP permit rule: {r.text.strip()}",
+           "Restrict ICMP to specific source ranges, or permit only echo-reply, "
+           "unreachable, and time-exceeded types required for diagnostics.")
+        for r in parse.find_objects(r"access-list.*permit icmp any any")
+    ]
+
+
+# ── Main auditor ──────────────────────────────────────────────────────────────
+
+def audit_ftd(filepath):
+    """Audit a Cisco FTD running config. Returns (findings, parse_obj)."""
+    parse = parse_ftd(filepath)
+    findings = (
+        _check_access_control_policy(parse)
+        + _check_threat_detection(parse)
+        + _check_intrusion_policy(parse)
+        + _check_ssl_inspection(parse)
+        + _check_any_any(parse)
+        + _check_missing_logging(parse)
+        + _check_deny_all(parse)
+        + _check_telnet(parse)
+        + _check_snmp_community(parse)
+        + _check_syslog_server(parse)
+        + _check_ssh_version(parse)
+        + _check_http_server(parse)
+        + _check_redundant_rules(parse)
+        + _check_icmp_any(parse)
+    )
+    return findings, parse

--- a/src/flintlock/paloalto.py
+++ b/src/flintlock/paloalto.py
@@ -146,9 +146,10 @@ def check_missing_description_pa(rules):
 
 
 def audit_paloalto(filepath):
+    """Return (findings, rules). rules is the parsed rule list for reuse in compliance checks."""
     rules, error = parse_paloalto(filepath)
     if error:
-        return [_f("HIGH", "hygiene", f"[ERROR] {error}", "")]
+        return [_f("HIGH", "hygiene", f"[ERROR] {error}", "")], []
 
     findings = []
     findings += check_any_any_pa(rules)
@@ -158,4 +159,4 @@ def audit_paloalto(filepath):
     findings += check_any_application_pa(rules)
     findings += check_no_security_profile_pa(rules)
     findings += check_missing_description_pa(rules)
-    return findings
+    return findings, rules

--- a/src/flintlock/schedule_store.py
+++ b/src/flintlock/schedule_store.py
@@ -1,0 +1,142 @@
+"""Schedule store — persists scheduled SSH audit jobs as individual JSON files.
+
+Passwords are stored base64-encoded in the schedule file. This is obfuscation,
+not encryption. Run Flintlock behind a firewall or reverse proxy with access
+controls and restrict SCHEDULES_FOLDER permissions (chmod 600).
+"""
+import base64
+import json
+import os
+import uuid
+from datetime import datetime
+
+SCHEDULES_FOLDER = os.environ.get("SCHEDULES_FOLDER", "/tmp/flintlock_schedules")
+
+VALID_VENDORS    = ("asa", "ftd", "fortinet", "paloalto")
+VALID_FREQS      = ("hourly", "daily", "weekly")
+VALID_FRAMEWORKS = ("", "cis", "pci", "nist", "hipaa")
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def _path(entry_id: str) -> str:
+    return os.path.join(SCHEDULES_FOLDER, f"{entry_id}.json")
+
+
+def _encode_password(password: str) -> str:
+    return base64.b64encode(password.encode("utf-8")).decode("ascii")
+
+
+def _decode_password(encoded: str) -> str:
+    try:
+        return base64.b64decode(encoded.encode("ascii")).decode("utf-8")
+    except Exception:
+        return ""
+
+
+def _strip_password(schedule: dict) -> dict:
+    """Return a copy of the schedule dict without the stored password."""
+    s = {k: v for k, v in schedule.items() if k != "password_enc"}
+    s["has_password"] = bool(schedule.get("password_enc"))
+    return s
+
+
+# ── Public CRUD ────────────────────────────────────────────────────────────────
+
+def list_schedules(include_password: bool = False) -> list:
+    os.makedirs(SCHEDULES_FOLDER, exist_ok=True)
+    result = []
+    for fname in sorted(os.listdir(SCHEDULES_FOLDER)):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(SCHEDULES_FOLDER, fname)) as f:
+                data = json.load(f)
+            result.append(data if include_password else _strip_password(data))
+        except Exception:
+            pass
+    return result
+
+
+def get_schedule(entry_id: str, include_password: bool = False) -> dict | None:
+    try:
+        with open(_path(entry_id)) as f:
+            data = json.load(f)
+        return data if include_password else _strip_password(data)
+    except FileNotFoundError:
+        return None
+
+
+def create_schedule(data: dict) -> dict:
+    os.makedirs(SCHEDULES_FOLDER, exist_ok=True)
+    entry_id = uuid.uuid4().hex
+    schedule = {
+        "id":           entry_id,
+        "name":         str(data.get("name", "Unnamed Schedule"))[:80],
+        "vendor":       str(data.get("vendor", "asa")),
+        "host":         str(data.get("host", "")),
+        "port":         int(data.get("port", 22)),
+        "username":     str(data.get("username", "")),
+        "password_enc": _encode_password(str(data.get("password", ""))),
+        "tag":          str(data.get("tag", ""))[:64],
+        "compliance":   str(data.get("compliance", "")),
+        "frequency":    str(data.get("frequency", "daily")),
+        "hour":         int(data.get("hour", 2)),
+        "minute":       int(data.get("minute", 0)),
+        "day_of_week":  str(data.get("day_of_week", "mon")),
+        "enabled":      bool(data.get("enabled", True)),
+        "last_run":     None,
+        "last_status":  None,
+        "last_error":   None,
+        "created_at":   datetime.utcnow().isoformat(),
+    }
+    with open(_path(entry_id), "w") as f:
+        json.dump(schedule, f, indent=2)
+    return _strip_password(schedule)
+
+
+def update_schedule(entry_id: str, data: dict) -> dict | None:
+    schedule = get_schedule(entry_id, include_password=True)
+    if not schedule:
+        return None
+    for key in ("name", "vendor", "host", "tag", "compliance",
+                "frequency", "day_of_week", "enabled"):
+        if key in data:
+            schedule[key] = data[key]
+    for key in ("port", "hour", "minute"):
+        if key in data:
+            schedule[key] = int(data[key])
+    if "enabled" in data:
+        schedule["enabled"] = bool(data["enabled"])
+    if data.get("password"):
+        schedule["password_enc"] = _encode_password(str(data["password"]))
+    with open(_path(entry_id), "w") as f:
+        json.dump(schedule, f, indent=2)
+    return _strip_password(schedule)
+
+
+def delete_schedule(entry_id: str) -> bool:
+    try:
+        os.remove(_path(entry_id))
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def record_run(entry_id: str, status: str, error: str | None = None):
+    """Update last_run, last_status, last_error after a job executes."""
+    schedule = get_schedule(entry_id, include_password=True)
+    if not schedule:
+        return
+    schedule["last_run"]    = datetime.utcnow().isoformat()
+    schedule["last_status"] = status
+    schedule["last_error"]  = error
+    with open(_path(entry_id), "w") as f:
+        json.dump(schedule, f, indent=2)
+
+
+def get_password(entry_id: str) -> str:
+    schedule = get_schedule(entry_id, include_password=True)
+    if not schedule:
+        return ""
+    return _decode_password(schedule.get("password_enc", ""))

--- a/src/flintlock/scheduler_runner.py
+++ b/src/flintlock/scheduler_runner.py
@@ -1,0 +1,170 @@
+"""Background scheduler for automated SSH audits."""
+import logging
+import os
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+logger = logging.getLogger(__name__)
+
+APSCHEDULER_AVAILABLE = True
+
+_scheduler = None
+
+
+# ── Job execution ──────────────────────────────────────────────────────────────
+
+def _run_scheduled_audit(schedule_id: str):
+    """Execute one scheduled SSH audit and persist results."""
+    from .schedule_store import get_schedule, get_password, record_run
+    from .ssh_connector import connect_and_pull
+    from .archive import save_audit
+    from .license import check_license
+    from .activity_log import log_activity, ACTION_SSH_CONNECT
+    from .audit_engine import (
+        run_vendor_audit, run_compliance_checks,
+        _sort_findings, _build_summary, _findings_to_strings, _wrap_compliance,
+    )
+
+    schedule = get_schedule(schedule_id, include_password=True)
+    if not schedule or not schedule.get("enabled"):
+        return
+
+    vendor     = schedule["vendor"]
+    host       = schedule["host"]
+    port       = schedule["port"]
+    username   = schedule["username"]
+    password   = get_password(schedule_id)
+    tag        = schedule.get("tag") or f"{vendor.upper()}@{host}"
+    compliance = schedule.get("compliance") or None
+    label      = f"{vendor.upper()}@{host}"
+
+    upload_folder = os.environ.get("UPLOAD_FOLDER", "/tmp/flintlock_uploads")
+    os.makedirs(upload_folder, exist_ok=True)
+
+    # ── SSH pull ──────────────────────────────────────────────────────────────
+    temp_path = None
+    try:
+        temp_path, _ = connect_and_pull(
+            vendor, host, port, username, password,
+            timeout=30, upload_folder=upload_folder,
+        )
+    except Exception as e:
+        record_run(schedule_id, "error", str(e))
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=False,
+                     error=str(e), details={"host": host, "scheduled": True})
+        return
+
+    # ── Audit + compliance ────────────────────────────────────────────────────
+    try:
+        findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
+
+        if compliance:
+            licensed, _ = check_license()
+            if licensed:
+                raw = run_compliance_checks(vendor, compliance, parse, extra_data, temp_path)
+                findings += [_wrap_compliance(c) for c in raw]
+
+        findings = _sort_findings(findings)
+        summary  = _build_summary(findings)
+
+        save_audit(label, vendor, _findings_to_strings(findings), summary,
+                   config_path=temp_path, tag=tag)
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=True,
+                     details={"host": host, "scheduled": True,
+                               "total": summary.get("total", 0),
+                               "high": summary.get("high", 0)})
+        record_run(schedule_id, "ok")
+
+    except Exception as e:
+        record_run(schedule_id, "error", str(e))
+        log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=False,
+                     error=str(e), details={"host": host, "scheduled": True})
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+# ── Trigger factory ────────────────────────────────────────────────────────────
+
+def _build_trigger(schedule: dict):
+    freq   = schedule.get("frequency", "daily")
+    hour   = schedule.get("hour", 2)
+    minute = schedule.get("minute", 0)
+    dow    = schedule.get("day_of_week", "mon")
+
+    if freq == "hourly":
+        return CronTrigger(minute=minute)
+    if freq == "weekly":
+        return CronTrigger(day_of_week=dow, hour=hour, minute=minute)
+    return CronTrigger(hour=hour, minute=minute)
+
+
+# ── Lifecycle ──────────────────────────────────────────────────────────────────
+
+def start_scheduler():
+    """Start the APScheduler background scheduler and load all enabled jobs."""
+    global _scheduler
+    if not APSCHEDULER_AVAILABLE:
+        return
+    if _scheduler and _scheduler.running:
+        return
+
+    _scheduler = BackgroundScheduler(timezone="UTC")
+
+    from .schedule_store import list_schedules
+    for sched in list_schedules(include_password=True):
+        if sched.get("enabled"):
+            try:
+                _scheduler.add_job(
+                    _run_scheduled_audit,
+                    trigger=_build_trigger(sched),
+                    args=[sched["id"]],
+                    id=sched["id"],
+                    replace_existing=True,
+                )
+            except Exception as exc:
+                logger.warning("Could not schedule job %s: %s", sched.get("id"), exc)
+
+    _scheduler.start()
+    logger.info("Flintlock scheduler started with %d job(s)", len(_scheduler.get_jobs()))
+
+
+def stop_scheduler():
+    global _scheduler
+    if _scheduler and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+
+
+def reload_job(schedule_id: str, schedule: dict | None = None):
+    """Add, update, or remove a scheduler job for the given schedule ID."""
+    if not APSCHEDULER_AVAILABLE or not _scheduler:
+        return
+    # Always remove first
+    try:
+        _scheduler.remove_job(schedule_id)
+    except Exception:
+        pass
+    # Re-add if enabled
+    if schedule and schedule.get("enabled"):
+        try:
+            _scheduler.add_job(
+                _run_scheduled_audit,
+                trigger=_build_trigger(schedule),
+                args=[schedule_id],
+                id=schedule_id,
+                replace_existing=True,
+            )
+        except Exception as exc:
+            logger.warning("Could not reload job %s: %s", schedule_id, exc)
+
+
+def run_now(schedule_id: str):
+    """Fire the scheduled audit immediately in a daemon thread."""
+    import threading
+    t = threading.Thread(target=_run_scheduled_audit, args=(schedule_id,), daemon=True)
+    t.start()
+
+
+def scheduler_available() -> bool:
+    return APSCHEDULER_AVAILABLE

--- a/src/flintlock/settings.py
+++ b/src/flintlock/settings.py
@@ -1,0 +1,30 @@
+"""Global application settings — persisted as JSON."""
+import json
+import os
+
+SETTINGS_FILE = os.environ.get("SETTINGS_FILE", "/tmp/flintlock_settings/settings.json")
+
+DEFAULTS: dict = {
+    "auto_pdf": False,
+    "auto_archive": False,
+    "default_compliance": "",
+}
+
+
+def get_settings() -> dict:
+    """Return current settings merged with defaults (so new keys always present)."""
+    try:
+        with open(SETTINGS_FILE, "r") as f:
+            data = json.load(f)
+        return {**DEFAULTS, **{k: data[k] for k in DEFAULTS if k in data}}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return dict(DEFAULTS)
+
+
+def save_settings(data: dict) -> dict:
+    """Persist settings. Unknown keys are ignored. Returns the saved dict."""
+    merged = {k: data.get(k, DEFAULTS[k]) for k in DEFAULTS}
+    os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+    with open(SETTINGS_FILE, "w") as f:
+        json.dump(merged, f, indent=2)
+    return merged

--- a/src/flintlock/ssh_connector.py
+++ b/src/flintlock/ssh_connector.py
@@ -106,11 +106,20 @@ def _pull_paloalto(host, port, username, password, timeout):
         client.close()
 
 
+# ── Cisco FTD ─────────────────────────────────────────────────────────────────
+# FTD LINA CLI accepts the same commands as ASA for pulling the running config.
+
+def _pull_ftd(host, port, username, password, timeout):
+    """Pull FTD running config via LINA CLI (same as ASA)."""
+    return _pull_asa(host, port, username, password, timeout)
+
+
 # ── Main entrypoint ───────────────────────────────────────────────────────────
 
-_SUFFIXES = {"asa": ".txt", "fortinet": ".txt", "paloalto": ".xml"}
+_SUFFIXES = {"asa": ".txt", "ftd": ".txt", "fortinet": ".txt", "paloalto": ".xml"}
 _PULLERS  = {
     "asa":      _pull_asa,
+    "ftd":      _pull_ftd,
     "fortinet": _pull_fortinet,
     "paloalto": _pull_paloalto,
 }

--- a/src/flintlock/static/style.css
+++ b/src/flintlock/static/style.css
@@ -1074,3 +1074,249 @@ select:focus, input[type="text"]:focus {
   [data-theme="auto"] .cat-redundancy { background: rgba(255,255,255,0.05); color: #9999BB; border-color: rgba(255,255,255,0.15); }
   [data-theme="auto"] .cat-compliance { background: rgba(68,136,255,0.12);  color: #88AAFF; border-color: rgba(68,136,255,0.3); }
 }
+
+/* ===== Settings Tab ===== */
+.settings-group {
+  margin-bottom: 1.75rem;
+}
+.settings-group-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+  cursor: default;
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.settings-row-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text);
+}
+.settings-row-desc {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.settings-select {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.65rem;
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-width: 160px;
+}
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+.settings-saved-msg {
+  font-size: 0.85rem;
+  color: var(--pass);
+  font-weight: 500;
+}
+
+/* Toggle switch */
+.toggle-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.toggle-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.toggle-track {
+  display: inline-flex;
+  align-items: center;
+  width: 42px;
+  height: 24px;
+  background: var(--border);
+  border-radius: 12px;
+  transition: background 0.2s;
+  position: relative;
+}
+.toggle-switch input:checked + .toggle-track { background: var(--btn-primary-bg); }
+.toggle-thumb {
+  position: absolute;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+.toggle-switch input:checked + .toggle-track .toggle-thumb { transform: translateX(18px); }
+
+/* ── PDF row ── */
+.pdf-row { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-top: 1rem; }
+
+/* ── Bulk Audit ── */
+.bulk-result-row {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--card-bg);
+}
+.bulk-result-row.bulk-result-error { border-color: var(--high); }
+.bulk-result-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
+}
+.bulk-filename  { font-weight: 600; color: var(--text); word-break: break-all; }
+.bulk-vendor-tag {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--info-bg, #e8f0fe);
+  color: var(--info, #1a56db);
+  white-space: nowrap;
+}
+.bulk-score { font-size: 0.8rem; font-weight: 600; white-space: nowrap; }
+.score-good { color: var(--pass); }
+.score-warn { color: var(--medium); }
+.score-bad  { color: var(--high); }
+.bulk-status-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  margin-left: auto;
+  white-space: nowrap;
+}
+.badge-ok   { background: var(--pass-bg, #dcfce7); color: var(--pass, #16a34a); }
+.badge-fail { background: var(--high-bg, #fee2e2); color: var(--high, #dc2626); }
+.bulk-summary-row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+.bulk-archived {
+  font-size: 0.78rem;
+  color: var(--pass);
+  font-weight: 500;
+  margin-left: 0.25rem;
+}
+.bulk-findings-toggle {
+  font-size: 0.83rem;
+  color: var(--text-muted);
+}
+.bulk-findings-toggle summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 0.2rem 0;
+}
+.bulk-findings-list { margin-top: 0.5rem; }
+
+/* ── Schedules ── */
+.schedules-list { display: flex; flex-direction: column; gap: 0.6rem; }
+.schedule-entry {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.8rem 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: var(--card-bg);
+  flex-wrap: wrap;
+}
+.schedule-entry.schedule-disabled { opacity: 0.55; }
+.schedule-entry-left  { flex: 1; min-width: 0; }
+.schedule-entry-right {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.schedule-entry-info  { display: flex; flex-direction: column; gap: 0.2rem; }
+.schedule-name        { font-weight: 600; color: var(--text); }
+.schedule-status-pill {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+.pill-enabled  { background: var(--pass-bg, #dcfce7);   color: var(--pass, #16a34a); }
+.pill-disabled { background: var(--border);              color: var(--text-muted); }
+.alert-inline {
+  font-size: 0.83rem;
+  color: var(--high);
+  background: var(--high-bg, #fee2e2);
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+}
+
+/* ===== Audit mode toggle (Single File / Bulk) ===== */
+.audit-mode-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+.mode-btn {
+  padding: 0.4rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1.5px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.mode-btn:hover { border-color: var(--btn-primary-bg); color: var(--text); }
+.mode-btn.mode-active {
+  background: var(--btn-primary-bg);
+  border-color: var(--btn-primary-bg);
+  color: #fff;
+}
+
+/* ===== History sub-tabs (Audit History / Activity Log) ===== */
+.sub-tab-nav {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.25rem;
+  border-bottom: 2px solid var(--border);
+}
+.sub-tab-btn {
+  padding: 0.5rem 1.2rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.sub-tab-btn:hover { color: var(--text); }
+.sub-tab-btn.sub-tab-active {
+  color: var(--btn-primary-bg);
+  border-bottom-color: var(--btn-primary-bg);
+}

--- a/src/flintlock/templates/index.html
+++ b/src/flintlock/templates/index.html
@@ -70,15 +70,25 @@
 
     <!-- Tab nav -->
     <nav class="tab-nav" role="tablist">
-      <button class="tab-btn tab-active" data-tab="audit"    role="tab">&#128196; File Audit</button>
-      <button class="tab-btn"            data-tab="diff"     role="tab">&#8646; Compare Configs</button>
-      <button class="tab-btn"            data-tab="connect"  role="tab">&#128246; Live Connect</button>
-      <button class="tab-btn"            data-tab="history"  role="tab">&#128337; Audit History</button>
-      <button class="tab-btn"            data-tab="activity" role="tab">&#128203; Activity Log</button>
+      <button class="tab-btn tab-active" data-tab="audit"     role="tab">&#128196; Audit</button>
+      <button class="tab-btn"            data-tab="diff"      role="tab">&#8646; Compare</button>
+      <button class="tab-btn"            data-tab="connect"   role="tab">&#128246; Live Connect</button>
+      <button class="tab-btn"            data-tab="schedules" role="tab">&#128336; Schedules</button>
+      <button class="tab-btn"            data-tab="history"   role="tab">&#128337; History</button>
+      <button class="tab-btn"            data-tab="settings"  role="tab">&#9881; Settings</button>
     </nav>
 
-    <!-- ══════════════════════════════════════════════ FILE AUDIT ══ -->
+    <!-- ══════════════════════════════════════════════ AUDIT ══ -->
     <section class="tab-panel" id="tab-audit">
+
+      <!-- Audit mode toggle: Single File / Bulk -->
+      <div class="audit-mode-bar">
+        <button class="mode-btn mode-active" data-mode="single">Single File</button>
+        <button class="mode-btn" data-mode="bulk">Bulk</button>
+      </div>
+
+      <!-- ── Single File mode ── -->
+      <div id="audit-mode-single">
       <div class="card">
         <h2 class="card-title">Run Audit</h2>
         <form id="auditForm" enctype="multipart/form-data">
@@ -113,6 +123,7 @@
                 <option value="cis">CIS Benchmark</option>
                 <option value="pci">PCI-DSS</option>
                 <option value="nist">NIST SP 800-41</option>
+                <option value="hipaa">HIPAA Security Rule</option>
               </select>
             </div>
             <div class="form-group form-group-check">
@@ -143,7 +154,8 @@
         <div class="summary-grid" id="summaryGrid"></div>
         <div id="findingsList"></div>
         <div class="pdf-row hidden" id="pdfRow">
-          <a id="pdfLink" class="btn-download" href="#" download>&#8681; Download PDF Report</a>
+          <a id="pdfLink" class="btn-download" href="#" download>&#8681; Download PDF</a>
+          <a id="pdfViewLink" class="btn-secondary" href="#" target="_blank" rel="noopener">&#128196; View PDF</a>
         </div>
         <div class="archive-row hidden" id="archiveRow">
           <span class="archive-saved-msg">&#10003; Saved to Audit History &mdash;
@@ -151,6 +163,64 @@
           </span>
         </div>
       </div>
+      </div><!-- /audit-mode-single -->
+
+      <!-- ── Bulk mode ── -->
+      <div id="audit-mode-bulk" class="hidden">
+      <div class="card">
+        <h2 class="card-title">Bulk Audit</h2>
+        <p class="card-desc">Upload multiple firewall configs at once. Each file is audited independently and results are shown side-by-side.</p>
+        <form id="bulkForm" enctype="multipart/form-data">
+          <div class="form-grid">
+            <div class="form-group" style="grid-column:1/-1">
+              <label for="bulkConfigs">Config Files</label>
+              <div class="file-input-wrapper">
+                <input type="file" id="bulkConfigs" name="configs[]" multiple required />
+                <span class="file-label" id="bulkFileLabel">Choose one or more files&hellip;</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="bulkVendor">Vendor</label>
+              <select id="bulkVendor" name="vendor">
+                <option value="auto" selected>Auto-detect (recommended)</option>
+                <option value="aws">AWS Security Group</option>
+                <option value="azure">Azure NSG</option>
+                <option value="asa">Cisco</option>
+                <option value="fortinet">Fortinet</option>
+                <option value="paloalto">Palo Alto Networks</option>
+                <option value="pfsense">pfSense</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="bulkCompliance">Compliance Framework <span class="optional">(licensed)</span></label>
+              <select id="bulkCompliance" name="compliance">
+                <option value="">None</option>
+                <option value="cis">CIS Benchmark</option>
+                <option value="pci">PCI-DSS</option>
+                <option value="nist">NIST SP 800-41</option>
+                <option value="hipaa">HIPAA Security Rule</option>
+              </select>
+            </div>
+            <div class="form-group form-group-check">
+              <label class="checkbox-label">
+                <input type="checkbox" id="bulkArchive" name="archive" value="1" />
+                <span>Save all to Audit History</span>
+              </label>
+            </div>
+          </div>
+          <button type="submit" class="btn-primary" id="bulkBtn">
+            <span id="bulkText">Run Bulk Audit</span>
+            <span id="bulkSpinner" class="spinner hidden"></span>
+          </button>
+        </form>
+      </div>
+
+      <div class="card hidden" id="bulkResults">
+        <h2 class="card-title">Bulk Results</h2>
+        <div id="bulkResultsList"></div>
+      </div>
+      </div><!-- /audit-mode-bulk -->
+
     </section>
 
     <!-- ═════════════════════════════════════════ COMPARE CONFIGS ══ -->
@@ -252,6 +322,7 @@
                 <option value="cis">CIS Benchmark</option>
                 <option value="pci">PCI-DSS</option>
                 <option value="nist">NIST SP 800-41</option>
+                <option value="hipaa">HIPAA Security Rule</option>
               </select>
             </div>
           </div>
@@ -277,8 +348,17 @@
       </div>
     </section>
 
-    <!-- ═════════════════════════════════════════ AUDIT HISTORY ══════ -->
+    <!-- ═══════════════════════════════════════════════ HISTORY ══════ -->
     <section class="tab-panel hidden" id="tab-history">
+
+      <!-- History sub-tabs: Audit History / Activity Log -->
+      <div class="sub-tab-nav">
+        <button class="sub-tab-btn sub-tab-active" data-subtab="audits">&#128337; Audit History</button>
+        <button class="sub-tab-btn" data-subtab="activity">&#128203; Activity Log</button>
+      </div>
+
+      <!-- ── Audit History sub-tab ── -->
+      <div id="sub-audits">
       <div class="card">
         <div class="results-header">
           <h2 class="card-title" style="margin-bottom:0">Audit History</h2>
@@ -350,10 +430,10 @@
         <h2 class="card-title">Comparison</h2>
         <div id="compareContent"></div>
       </div>
-    </section>
+      </div><!-- /sub-audits -->
 
-    <!-- ══════════════════════════════════════════ ACTIVITY LOG ══════ -->
-    <section class="tab-panel hidden" id="tab-activity">
+      <!-- ── Activity Log sub-tab ── -->
+      <div id="sub-activity" class="hidden">
       <div class="card">
         <div class="results-header">
           <h2 class="card-title" style="margin-bottom:0">Activity Log</h2>
@@ -367,12 +447,174 @@
           <p class="text-muted">Loading&hellip;</p>
         </div>
       </div>
+      </div><!-- /sub-activity -->
+
+    </section>
+
+    <!-- ═══════════════════════════════════════════════ SCHEDULES ══════ -->
+    <section class="tab-panel hidden" id="tab-schedules">
+      <div class="card">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Scheduled Audits</h2>
+          <button class="btn-secondary" id="refreshSchedulesBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#8635; Refresh</button>
+        </div>
+        <p class="card-desc">Automatically run SSH audits on a recurring schedule. Results are saved to Audit History.</p>
+        <div id="schedulesList" class="schedules-list">
+          <p class="text-muted">Loading&hellip;</p>
+        </div>
+      </div>
+
+      <!-- New / Edit Schedule Form -->
+      <div class="card" id="scheduleFormCard">
+        <h2 class="card-title" id="scheduleFormTitle">New Schedule</h2>
+        <form id="scheduleForm">
+          <input type="hidden" id="scheduleId" value="" />
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="schedName">Name</label>
+              <input type="text" id="schedName" name="name" placeholder="My ASA01 daily audit" maxlength="80" autocomplete="off" required />
+            </div>
+            <div class="form-group">
+              <label for="schedVendor">Vendor</label>
+              <select id="schedVendor" name="vendor">
+                <option value="asa">Cisco</option>
+                <option value="fortinet">Fortinet</option>
+                <option value="paloalto">Palo Alto Networks</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="schedHost">Host / IP</label>
+              <input type="text" id="schedHost" name="host" placeholder="192.168.1.1" autocomplete="off" required />
+            </div>
+            <div class="form-group">
+              <label for="schedPort">SSH Port</label>
+              <input type="text" id="schedPort" name="port" value="22" placeholder="22" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="schedUser">Username</label>
+              <input type="text" id="schedUser" name="username" placeholder="admin" autocomplete="off" required />
+            </div>
+            <div class="form-group">
+              <label for="schedPass">Password</label>
+              <input type="password" id="schedPass" name="password" placeholder="leave blank to keep existing" autocomplete="new-password" />
+            </div>
+            <div class="form-group">
+              <label for="schedTag">Device Tag</label>
+              <input type="text" id="schedTag" name="tag" placeholder="ASA01" maxlength="64" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="schedCompliance">Compliance <span class="optional">(licensed)</span></label>
+              <select id="schedCompliance" name="compliance">
+                <option value="">None</option>
+                <option value="cis">CIS Benchmark</option>
+                <option value="pci">PCI-DSS</option>
+                <option value="nist">NIST SP 800-41</option>
+                <option value="hipaa">HIPAA Security Rule</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="schedFrequency">Frequency</label>
+              <select id="schedFrequency" name="frequency">
+                <option value="hourly">Hourly</option>
+                <option value="daily" selected>Daily</option>
+                <option value="weekly">Weekly</option>
+              </select>
+            </div>
+            <div class="form-group" id="schedHourGroup">
+              <label for="schedHour">Hour (UTC, 0&ndash;23)</label>
+              <input type="number" id="schedHour" name="hour" value="2" min="0" max="23" />
+            </div>
+            <div class="form-group">
+              <label for="schedMinute">Minute (0&ndash;59)</label>
+              <input type="number" id="schedMinute" name="minute" value="0" min="0" max="59" />
+            </div>
+            <div class="form-group" id="schedDowGroup" style="display:none">
+              <label for="schedDow">Day of Week</label>
+              <select id="schedDow" name="day_of_week">
+                <option value="mon" selected>Monday</option>
+                <option value="tue">Tuesday</option>
+                <option value="wed">Wednesday</option>
+                <option value="thu">Thursday</option>
+                <option value="fri">Friday</option>
+                <option value="sat">Saturday</option>
+                <option value="sun">Sunday</option>
+              </select>
+            </div>
+            <div class="form-group form-group-check">
+              <label class="checkbox-label">
+                <input type="checkbox" id="schedEnabled" name="enabled" checked />
+                <span>Enabled</span>
+              </label>
+            </div>
+          </div>
+          <div style="display:flex;gap:0.75rem;align-items:center;flex-wrap:wrap">
+            <button type="submit" class="btn-primary" id="schedSaveBtn">Save Schedule</button>
+            <button type="button" class="btn-secondary" id="schedCancelBtn">Cancel</button>
+            <span class="settings-saved-msg hidden" id="schedSavedMsg">&#10003; Saved</span>
+            <span class="alert-inline hidden" id="schedErrorMsg"></span>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <!-- ════════════════════════════════════════════════ SETTINGS ══════ -->
+    <section class="tab-panel hidden" id="tab-settings">
+      <div class="card">
+        <h2 class="card-title">Settings</h2>
+        <p class="card-desc">Global defaults applied to every audit. Individual audit options always override these defaults.</p>
+
+        <div class="settings-group">
+          <h3 class="settings-group-title">File Audit Defaults</h3>
+          <label class="settings-row">
+            <div class="settings-row-info">
+              <span class="settings-row-label">Always generate PDF report</span>
+              <span class="settings-row-desc">Pre-check &ldquo;Generate PDF Report&rdquo; on every file audit.</span>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="setting-auto-pdf" />
+              <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </label>
+          </label>
+          <label class="settings-row">
+            <div class="settings-row-info">
+              <span class="settings-row-label">Always save to Audit History</span>
+              <span class="settings-row-desc">Pre-check &ldquo;Save to Audit History&rdquo; on every file audit.</span>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="setting-auto-archive" />
+              <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </label>
+          </label>
+        </div>
+
+        <div class="settings-group">
+          <h3 class="settings-group-title">Compliance Default</h3>
+          <label class="settings-row">
+            <div class="settings-row-info">
+              <span class="settings-row-label">Default compliance framework</span>
+              <span class="settings-row-desc">Pre-select a framework on the File Audit and Live Connect forms.</span>
+            </div>
+            <select id="setting-default-compliance" class="settings-select">
+              <option value="">None</option>
+              <option value="cis">CIS Benchmark</option>
+              <option value="pci">PCI-DSS</option>
+              <option value="nist">NIST SP 800-41</option>
+              <option value="hipaa">HIPAA Security Rule</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="settings-actions">
+          <button class="btn-primary" id="saveSettingsBtn">Save Settings</button>
+          <span class="settings-saved-msg hidden" id="settingsSavedMsg">&#10003; Saved</span>
+        </div>
+      </div>
     </section>
 
   </main>
 
   <footer class="footer">
-    <p>Flintlock v1.1 &mdash; Firewall Security Auditor</p>
+    <p>Flintlock v1.2 &mdash; Firewall Security Auditor</p>
   </footer>
 
   <script>
@@ -440,14 +682,36 @@
   function switchTab(tabId) {
     tabBtns.forEach(b => b.classList.toggle("tab-active", b.dataset.tab === tabId));
     tabPanels.forEach(p => p.classList.toggle("hidden", p.id !== "tab-" + tabId));
-    if (tabId === "history")  { loadHistory(); loadTrends(); }
-    if (tabId === "activity") loadActivity();
+    if (tabId === "history")   { loadHistory(); loadTrends(); }
+    if (tabId === "settings")  applySettingsToUI();
+    if (tabId === "schedules") loadSchedules();
   }
   tabBtns.forEach(btn => btn.addEventListener("click", () => switchTab(btn.dataset.tab)));
 
+  // ════════════════════════════════════════ AUDIT MODE TOGGLE (single/bulk) ══
+  function switchAuditMode(mode) {
+    document.querySelectorAll(".mode-btn").forEach(b => b.classList.toggle("mode-active", b.dataset.mode === mode));
+    document.getElementById("audit-mode-single").classList.toggle("hidden", mode !== "single");
+    document.getElementById("audit-mode-bulk").classList.toggle("hidden", mode !== "bulk");
+  }
+  document.querySelectorAll(".mode-btn").forEach(btn =>
+    btn.addEventListener("click", () => switchAuditMode(btn.dataset.mode))
+  );
+
+  // ═══════════════════════════════════════ HISTORY SUB-TABS (audits/activity) ══
+  function switchHistorySubTab(subtab) {
+    document.querySelectorAll(".sub-tab-btn").forEach(b => b.classList.toggle("sub-tab-active", b.dataset.subtab === subtab));
+    document.getElementById("sub-audits").classList.toggle("hidden", subtab !== "audits");
+    document.getElementById("sub-activity").classList.toggle("hidden", subtab !== "activity");
+    if (subtab === "activity") loadActivity();
+  }
+  document.querySelectorAll(".sub-tab-btn").forEach(btn =>
+    btn.addEventListener("click", () => switchHistorySubTab(btn.dataset.subtab))
+  );
+
   // ═════════════════════════════════════════════════════ FILE AUDIT ══════
   const VENDOR_LABELS = {
-    asa: "Cisco", paloalto: "Palo Alto Networks", fortinet: "Fortinet",
+    asa: "Cisco", ftd: "Cisco", paloalto: "Palo Alto Networks", fortinet: "Fortinet",
     pfsense: "pfSense", aws: "AWS Security Group", azure: "Azure NSG"
   };
 
@@ -643,6 +907,12 @@
       tag.classList.remove("hidden");
     } else { tag.classList.add("hidden"); }
 
+    // Auto-fill device tag from config hostname if the field is still empty
+    if (data.detected_hostname) {
+      const tagField = document.getElementById("deviceTag");
+      if (!tagField.value.trim()) tagField.value = data.detected_hostname;
+    }
+
     const warn = document.getElementById("licenseWarning");
     if (data.license_warning) { warn.innerHTML = data.license_warning; warn.classList.remove("hidden"); }
     else { warn.classList.add("hidden"); }
@@ -656,8 +926,11 @@
       : `<div class="finding finding-pass">[PASS] No issues found</div>`;
 
     const pdfRow = document.getElementById("pdfRow");
-    if (data.report) { document.getElementById("pdfLink").href = "/reports/" + data.report; pdfRow.classList.remove("hidden"); }
-    else { pdfRow.classList.add("hidden"); }
+    if (data.report) {
+      document.getElementById("pdfLink").href     = "/reports/" + data.report;
+      document.getElementById("pdfViewLink").href = "/reports/" + data.report + "/view";
+      pdfRow.classList.remove("hidden");
+    } else { pdfRow.classList.add("hidden"); }
 
     if (data.archive_id) { document.getElementById("archiveRow").classList.remove("hidden"); }
     else { document.getElementById("archiveRow").classList.add("hidden"); }
@@ -1032,9 +1305,10 @@
       { label: "Medium", value: s.medium, cls: "sev-medium", filter: "medium" },
       { label: "Total",  value: s.total,  cls: "sev-total",  filter: "all" },
     ];
-    if (s.pci_high  || s.pci_medium)  { items.push({ label:"PCI High",   value:s.pci_high,   cls:"sev-compliance",filter:"compliance"}); items.push({ label:"PCI Med",    value:s.pci_medium, cls:"sev-compliance",filter:"compliance"}); }
-    if (s.cis_high  || s.cis_medium)  { items.push({ label:"CIS High",   value:s.cis_high,   cls:"sev-compliance",filter:"compliance"}); items.push({ label:"CIS Med",    value:s.cis_medium, cls:"sev-compliance",filter:"compliance"}); }
-    if (s.nist_high || s.nist_medium) { items.push({ label:"NIST High",  value:s.nist_high,  cls:"sev-compliance",filter:"compliance"}); items.push({ label:"NIST Med",   value:s.nist_medium,cls:"sev-compliance",filter:"compliance"}); }
+    if (s.pci_high   || s.pci_medium)   { items.push({ label:"PCI High",   value:s.pci_high,    cls:"sev-compliance",filter:"compliance"}); items.push({ label:"PCI Med",    value:s.pci_medium,  cls:"sev-compliance",filter:"compliance"}); }
+    if (s.cis_high   || s.cis_medium)   { items.push({ label:"CIS High",   value:s.cis_high,    cls:"sev-compliance",filter:"compliance"}); items.push({ label:"CIS Med",    value:s.cis_medium,  cls:"sev-compliance",filter:"compliance"}); }
+    if (s.nist_high  || s.nist_medium)  { items.push({ label:"NIST High",  value:s.nist_high,   cls:"sev-compliance",filter:"compliance"}); items.push({ label:"NIST Med",   value:s.nist_medium, cls:"sev-compliance",filter:"compliance"}); }
+    if (s.hipaa_high || s.hipaa_medium) { items.push({ label:"HIPAA High", value:s.hipaa_high,  cls:"sev-compliance",filter:"compliance"}); items.push({ label:"HIPAA Med",  value:s.hipaa_medium,cls:"sev-compliance",filter:"compliance"}); }
     let html = items.map(i =>
       `<div class="summary-box ${i.cls}" data-filter="${i.filter}" title="Click to filter">
          <span class="summary-val">${i.value}</span><span class="summary-lbl">${i.label}</span>
@@ -1051,10 +1325,10 @@
 
   function findingClass(f) {
     const msg = typeof f === "object" ? f.message : f;
-    if (msg.includes("[HIGH]")   && !msg.match(/PCI-|CIS-|NIST-/)) return "finding-high";
-    if (msg.includes("[MEDIUM]") && !msg.match(/PCI-|CIS-|NIST-/)) return "finding-medium";
-    if (msg.match(/PCI-HIGH|CIS-HIGH|NIST-HIGH/))                   return "finding-compliance-high";
-    if (msg.match(/PCI-MEDIUM|CIS-MEDIUM|NIST-MEDIUM/))             return "finding-compliance-medium";
+    if (msg.includes("[HIGH]")   && !msg.match(/PCI-|CIS-|NIST-|HIPAA-/)) return "finding-high";
+    if (msg.includes("[MEDIUM]") && !msg.match(/PCI-|CIS-|NIST-|HIPAA-/)) return "finding-medium";
+    if (msg.match(/PCI-HIGH|CIS-HIGH|NIST-HIGH|HIPAA-HIGH/))               return "finding-compliance-high";
+    if (msg.match(/PCI-MEDIUM|CIS-MEDIUM|NIST-MEDIUM|HIPAA-MEDIUM/))       return "finding-compliance-medium";
     return "finding-info";
   }
 
@@ -1086,7 +1360,7 @@
     document.getElementById(textId).textContent = loading ? label : label.replace(/\u2026$/, "").trim();
     document.getElementById(spinnerId).classList.toggle("hidden", !loading);
     if (!loading) {
-      const origLabels = { submitBtn:"Run Audit", diffBtn:"Compare", connectBtn:"Connect & Audit" };
+      const origLabels = { submitBtn:"Run Audit", bulkBtn:"Run Bulk Audit", diffBtn:"Compare", connectBtn:"Connect & Audit" };
       document.getElementById(textId).textContent = origLabels[btnId] || label;
     }
   }
@@ -1094,6 +1368,298 @@
   function escHtml(s) {
     return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
   }
+
+  // ══════════════════════════════════════════════════════ BULK AUDIT ══
+  document.getElementById("bulkConfigs").addEventListener("change", function () {
+    const n = this.files.length;
+    document.getElementById("bulkFileLabel").textContent =
+      n === 0 ? "Choose one or more files\u2026" :
+      n === 1 ? this.files[0].name : n + " files selected";
+  });
+
+  document.getElementById("bulkForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    setLoading("bulkBtn", "bulkText", "bulkSpinner", "Running\u2026", true);
+    document.getElementById("bulkResults").classList.add("hidden");
+    try {
+      const res  = await fetch("/bulk_audit", { method: "POST", body: new FormData(this) });
+      const data = await res.json();
+      if (data.error) {
+        document.getElementById("bulkResults").classList.remove("hidden");
+        document.getElementById("bulkResultsList").innerHTML =
+          `<div class="alert alert-error">${escHtml(data.error)}</div>`;
+        return;
+      }
+      renderBulkResults(data);
+    } catch (err) {
+      document.getElementById("bulkResults").classList.remove("hidden");
+      document.getElementById("bulkResultsList").innerHTML =
+        `<div class="alert alert-error">Unexpected error: ${escHtml(err.message)}</div>`;
+    } finally {
+      setLoading("bulkBtn", "bulkText", "bulkSpinner", "Run Bulk Audit", false);
+    }
+  });
+
+  function renderBulkResults(results) {
+    const el = document.getElementById("bulkResultsList");
+    if (!results.length) { el.innerHTML = `<p class="text-muted">No files processed.</p>`; return; }
+    el.innerHTML = results.map(r => {
+      const vendor = VENDOR_LABELS[r.vendor] || r.vendor || "Unknown";
+      const s = r.summary || {};
+      if (r.status === "error") {
+        return `<div class="bulk-result-row bulk-result-error">
+          <div class="bulk-result-header">
+            <span class="bulk-filename">${escHtml(r.filename)}</span>
+            <span class="bulk-status-badge badge-fail">&#10007; Error</span>
+          </div>
+          <div class="alert alert-error" style="margin:0.5rem 0 0">${escHtml(r.error || "Unknown error")}</div>
+        </div>`;
+      }
+      const scoreVal = s.score !== undefined ? s.score : "—";
+      const scoreCls = s.score >= 80 ? "score-good" : s.score >= 50 ? "score-warn" : "score-bad";
+      return `<div class="bulk-result-row">
+        <div class="bulk-result-header">
+          <span class="bulk-filename">${escHtml(r.filename)}</span>
+          <span class="bulk-vendor-tag">${escHtml(vendor)}</span>
+          <span class="bulk-score ${scoreCls}">${scoreVal}/100</span>
+          <span class="bulk-status-badge badge-ok">&#10003; OK</span>
+        </div>
+        <div class="bulk-summary-row">
+          <span class="history-badge sev-high" title="High">${s.high||0} H</span>
+          <span class="history-badge sev-medium" title="Medium">${s.medium||0} M</span>
+          <span class="history-badge sev-total" title="Total">${s.total||0} Total</span>
+          ${r.archive_id ? `<span class="bulk-archived">&#10003; Saved to History</span>` : ""}
+        </div>
+        <details class="bulk-findings-toggle">
+          <summary>${(r.enriched_findings||r.findings||[]).length} finding(s) &mdash; click to expand</summary>
+          <div class="bulk-findings-list">${(r.enriched_findings||[]).length
+            ? (r.enriched_findings).map(f => buildFindingHTML(f)).join("")
+            : (r.findings||[]).map(f => `<div class="finding finding-info">${escHtml(f)}</div>`).join("")
+            || `<div class="finding finding-pass">[PASS] No issues found</div>`}
+          </div>
+        </details>
+      </div>`;
+    }).join("");
+    document.getElementById("bulkResults").classList.remove("hidden");
+  }
+
+  // ══════════════════════════════════════════════════════ SCHEDULES ══
+  let schedulesData = [];
+
+  async function loadSchedules() {
+    document.getElementById("schedulesList").innerHTML = `<p class="text-muted">Loading\u2026</p>`;
+    try {
+      const res = await fetch("/schedules");
+      schedulesData = await res.json();
+      renderSchedules(schedulesData);
+    } catch (err) {
+      document.getElementById("schedulesList").innerHTML =
+        `<div class="alert alert-error">Failed to load schedules: ${escHtml(err.message)}</div>`;
+    }
+  }
+
+  const FREQ_LABELS = { hourly: "Hourly", daily: "Daily", weekly: "Weekly" };
+  const DOW_LABELS  = { mon:"Mon", tue:"Tue", wed:"Wed", thu:"Thu", fri:"Fri", sat:"Sat", sun:"Sun" };
+  const COMP_LABELS = { cis:"CIS", pci:"PCI-DSS", nist:"NIST", hipaa:"HIPAA", "":"—" };
+
+  function renderSchedules(list) {
+    const el = document.getElementById("schedulesList");
+    if (!list.length) {
+      el.innerHTML = `<p class="text-muted">No scheduled audits yet. Fill in the form below to create one.</p>`;
+      return;
+    }
+    el.innerHTML = list.map(s => {
+      const freq    = FREQ_LABELS[s.frequency] || s.frequency;
+      const vendor  = VENDOR_LABELS[s.vendor]  || s.vendor;
+      const comp    = COMP_LABELS[s.compliance||""] || s.compliance || "—";
+      const lastRun = s.last_run ? new Date(s.last_run).toLocaleString() : "Never";
+      const lastSt  = s.last_status === "ok"    ? `<span class="activity-ok">&#10003; OK</span>` :
+                      s.last_status === "error"  ? `<span class="activity-fail">&#10007; Error</span>` : "—";
+      const timing  = s.frequency === "weekly"
+        ? `${DOW_LABELS[s.day_of_week]||s.day_of_week} ${String(s.hour).padStart(2,"0")}:${String(s.minute).padStart(2,"0")} UTC`
+        : s.frequency === "hourly"
+        ? `Every hour at :${String(s.minute).padStart(2,"0")}`
+        : `${String(s.hour).padStart(2,"0")}:${String(s.minute).padStart(2,"0")} UTC`;
+      return `<div class="schedule-entry ${s.enabled ? "" : "schedule-disabled"}">
+        <div class="schedule-entry-left">
+          <div class="schedule-entry-info">
+            <span class="schedule-name">${escHtml(s.name)}</span>
+            <span class="history-meta">${escHtml(vendor)} &bull; ${escHtml(s.host)} &bull; ${freq} @ ${timing} &bull; Compliance: ${escHtml(comp)}</span>
+            <span class="history-meta">Last run: ${escHtml(lastRun)} ${lastSt}${s.last_error ? ` &mdash; <span class="activity-error">${escHtml(s.last_error)}</span>` : ""}</span>
+          </div>
+        </div>
+        <div class="schedule-entry-right">
+          <span class="schedule-status-pill ${s.enabled ? "pill-enabled" : "pill-disabled"}">${s.enabled ? "Enabled" : "Disabled"}</span>
+          <button class="btn-secondary btn-sm" data-sched-run="${escHtml(s.id)}" title="Run now">&#9654; Run Now</button>
+          <button class="btn-secondary btn-sm" data-sched-edit="${escHtml(s.id)}" title="Edit">&#9998; Edit</button>
+          <button class="btn-danger btn-sm"    data-sched-del="${escHtml(s.id)}"  title="Delete">&#128465;</button>
+        </div>
+      </div>`;
+    }).join("");
+
+    // Listeners are delegated to the parent — no per-render attachment needed.
+  }
+
+  function populateScheduleForm(s) {
+    document.getElementById("scheduleFormTitle").textContent = "Edit Schedule";
+    document.getElementById("scheduleId").value        = s.id;
+    document.getElementById("schedName").value         = s.name || "";
+    document.getElementById("schedVendor").value       = s.vendor || "asa";
+    document.getElementById("schedHost").value         = s.host || "";
+    document.getElementById("schedPort").value         = s.port || 22;
+    document.getElementById("schedUser").value         = s.username || "";
+    document.getElementById("schedPass").value         = "";  // never pre-fill password
+    document.getElementById("schedTag").value          = s.tag || "";
+    document.getElementById("schedCompliance").value   = s.compliance || "";
+    document.getElementById("schedFrequency").value    = s.frequency || "daily";
+    document.getElementById("schedHour").value         = s.hour !== undefined ? s.hour : 2;
+    document.getElementById("schedMinute").value       = s.minute !== undefined ? s.minute : 0;
+    document.getElementById("schedDow").value          = s.day_of_week || "mon";
+    document.getElementById("schedEnabled").checked    = !!s.enabled;
+    toggleScheduleFreqFields(s.frequency || "daily");
+    document.getElementById("scheduleFormCard").scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function toggleScheduleFreqFields(freq) {
+    document.getElementById("schedHourGroup").style.display = freq === "hourly" ? "none" : "";
+    document.getElementById("schedDowGroup").style.display  = freq === "weekly" ? ""     : "none";
+  }
+
+  document.getElementById("schedFrequency").addEventListener("change", function () {
+    toggleScheduleFreqFields(this.value);
+  });
+
+  document.getElementById("schedCancelBtn").addEventListener("click", function () {
+    document.getElementById("scheduleForm").reset();
+    document.getElementById("scheduleId").value = "";
+    document.getElementById("scheduleFormTitle").textContent = "New Schedule";
+    document.getElementById("schedSavedMsg").classList.add("hidden");
+    document.getElementById("schedErrorMsg").classList.add("hidden");
+    toggleScheduleFreqFields("daily");
+  });
+
+  document.getElementById("scheduleForm").addEventListener("submit", async function (e) {
+    e.preventDefault();
+    const schedId = document.getElementById("scheduleId").value.trim();
+    const payload = {
+      name:        document.getElementById("schedName").value.trim(),
+      vendor:      document.getElementById("schedVendor").value,
+      host:        document.getElementById("schedHost").value.trim(),
+      port:        parseInt(document.getElementById("schedPort").value) || 22,
+      username:    document.getElementById("schedUser").value.trim(),
+      tag:         document.getElementById("schedTag").value.trim(),
+      compliance:  document.getElementById("schedCompliance").value,
+      frequency:   document.getElementById("schedFrequency").value,
+      hour:        parseInt(document.getElementById("schedHour").value) || 0,
+      minute:      parseInt(document.getElementById("schedMinute").value) || 0,
+      day_of_week: document.getElementById("schedDow").value,
+      enabled:     document.getElementById("schedEnabled").checked,
+    };
+    const pass = document.getElementById("schedPass").value;
+    if (pass) payload.password = pass;
+
+    try {
+      const url    = schedId ? "/schedules/" + schedId : "/schedules";
+      const method = schedId ? "PUT" : "POST";
+      const res    = await fetch(url, {
+        method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (data.error) {
+        const errEl = document.getElementById("schedErrorMsg");
+        errEl.textContent = data.error;
+        errEl.classList.remove("hidden");
+        return;
+      }
+      document.getElementById("schedErrorMsg").classList.add("hidden");
+      const msg = document.getElementById("schedSavedMsg");
+      msg.classList.remove("hidden");
+      setTimeout(() => msg.classList.add("hidden"), 2500);
+      // Reset form for new entry, keep editing state for updates
+      if (!schedId) {
+        this.reset();
+        document.getElementById("scheduleId").value = "";
+        toggleScheduleFreqFields("daily");
+      }
+      await loadSchedules();
+    } catch (err) {
+      alert("Failed to save schedule: " + err.message);
+    }
+  });
+
+  document.getElementById("refreshSchedulesBtn").addEventListener("click", loadSchedules);
+
+  // Delegated event handler for schedule list — set up once, works across re-renders.
+  document.getElementById("schedulesList").addEventListener("click", async function (e) {
+    const runBtn  = e.target.closest("[data-sched-run]");
+    const editBtn = e.target.closest("[data-sched-edit]");
+    const delBtn  = e.target.closest("[data-sched-del]");
+
+    if (runBtn) {
+      runBtn.disabled = true;
+      await fetch("/schedules/" + runBtn.dataset.schedRun + "/run", { method: "POST" });
+      runBtn.disabled = false;
+      alert("Audit queued — check Audit History in a moment.");
+    } else if (editBtn) {
+      const sched = schedulesData.find(s => s.id === editBtn.dataset.schedEdit);
+      if (sched) populateScheduleForm(sched);
+    } else if (delBtn) {
+      if (!confirm("Delete this schedule?")) return;
+      await fetch("/schedules/" + delBtn.dataset.schedDel, { method: "DELETE" });
+      await loadSchedules();
+    }
+  });
+
+  // ═════════════════════════════════════════════════════════ SETTINGS ══
+  let appSettings = { auto_pdf: false, auto_archive: false, default_compliance: "" };
+
+  async function loadSettings() {
+    try {
+      const res = await fetch("/settings");
+      appSettings = await res.json();
+      applySettingsToUI();
+      applySettingsToForm();
+    } catch (_) {}
+  }
+
+  function applySettingsToUI() {
+    document.getElementById("setting-auto-pdf").checked         = !!appSettings.auto_pdf;
+    document.getElementById("setting-auto-archive").checked     = !!appSettings.auto_archive;
+    document.getElementById("setting-default-compliance").value = appSettings.default_compliance || "";
+  }
+
+  function applySettingsToForm() {
+    document.getElementById("report").checked  = !!appSettings.auto_pdf;
+    document.getElementById("archive").checked = !!appSettings.auto_archive;
+    const comp = appSettings.default_compliance || "";
+    if (comp) {
+      document.getElementById("compliance").value     = comp;
+      document.getElementById("connCompliance").value = comp;
+    }
+  }
+
+  document.getElementById("saveSettingsBtn").addEventListener("click", async function () {
+    const data = {
+      auto_pdf:            document.getElementById("setting-auto-pdf").checked,
+      auto_archive:        document.getElementById("setting-auto-archive").checked,
+      default_compliance:  document.getElementById("setting-default-compliance").value,
+    };
+    try {
+      const res = await fetch("/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      appSettings = await res.json();
+      applySettingsToForm();
+      const msg = document.getElementById("settingsSavedMsg");
+      msg.classList.remove("hidden");
+      setTimeout(() => msg.classList.add("hidden"), 2500);
+    } catch (_) {}
+  });
+
+  // Load settings on startup and apply defaults to the audit form
+  loadSettings();
   </script>
 </body>
 </html>

--- a/src/flintlock/web.py
+++ b/src/flintlock/web.py
@@ -1,27 +1,34 @@
+import atexit
+import json
 import os
+import re
 import uuid
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from flask import Flask, render_template, request, jsonify, send_file
-from ciscoconfparse import CiscoConfParse
 
 from .license import check_license, activate_license, deactivate_license
-from .compliance import (
-    check_cis_compliance, check_pci_compliance, check_nist_compliance,
-    check_cis_compliance_pa, check_pci_compliance_pa, check_nist_compliance_pa,
-    check_cis_compliance_forti, check_pci_compliance_forti, check_nist_compliance_forti,
-    check_cis_compliance_pf, check_pci_compliance_pf, check_nist_compliance_pf,
-)
-from .paloalto import audit_paloalto, parse_paloalto
-from .fortinet import audit_fortinet
-from .pfsense import audit_pfsense
-from .aws import audit_aws_sg
-from .azure import audit_azure_nsg
+from .ftd import is_ftd_config
 from .reporter import generate_report
+from .audit_engine import (
+    _findings_to_strings, _wrap_compliance,
+    _sort_findings, _build_summary,
+    run_vendor_audit, run_compliance_checks,
+)
 from .diff import diff_configs
 from .archive import save_audit, list_archive, get_entry, delete_entry, compare_entries
 from .activity_log import (
     log_activity, list_activity, delete_activity_entry, clear_activity,
     ACTION_FILE_AUDIT, ACTION_SSH_CONNECT, ACTION_CONFIG_DIFF,
+)
+from .settings import get_settings, save_settings
+from .schedule_store import (
+    list_schedules, get_schedule, create_schedule,
+    update_schedule, delete_schedule,
+)
+from .scheduler_runner import (
+    start_scheduler, stop_scheduler, reload_job,
+    run_now as scheduler_run_now, scheduler_available,
 )
 
 UPLOAD_FOLDER    = os.environ.get("UPLOAD_FOLDER",    "/tmp/flintlock_uploads")
@@ -32,12 +39,15 @@ ACTIVITY_FOLDER  = os.environ.get("ACTIVITY_FOLDER",  "/tmp/flintlock_activity")
 for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER, ACTIVITY_FOLDER):
     os.makedirs(_d, exist_ok=True)
 
+# Settings folder is created lazily by settings.py on first save
+
 app = Flask(__name__, template_folder="templates", static_folder="static")
 app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10 MB upload limit
 
 
 VENDOR_DISPLAY = {
     "asa":      "Cisco",
+    "ftd":      "Cisco",
     "paloalto": "Palo Alto Networks",
     "fortinet": "Fortinet",
     "pfsense":  "pfSense",
@@ -46,29 +56,6 @@ VENDOR_DISPLAY = {
 }
 
 ALL_VENDORS = set(VENDOR_DISPLAY)
-
-
-def _f(severity, category, message, remediation=""):
-    """Build a structured finding dict."""
-    return {"severity": severity, "category": category, "message": message, "remediation": remediation}
-
-
-def _finding_msg(f):
-    """Extract the message string from a finding (dict or legacy string)."""
-    return f["message"] if isinstance(f, dict) else f
-
-
-def _findings_to_strings(findings):
-    """Convert findings list (dicts or strings) to plain strings for storage/PDF."""
-    return [_finding_msg(f) for f in findings]
-
-
-def _wrap_compliance(s):
-    """Wrap a compliance string finding as a minimal dict."""
-    if isinstance(s, dict):
-        return s
-    sev = "HIGH" if any(x in s for x in ("-HIGH", "[HIGH]")) else "MEDIUM"
-    return {"severity": sev, "category": "compliance", "message": s, "remediation": None}
 
 
 # ── Vendor auto-detection ─────────────────────────────────────────────────────
@@ -82,7 +69,6 @@ def detect_vendor(content: str, filename: str) -> str | None:
     # JSON-based: AWS or Azure
     if stripped.startswith("{") or stripped.startswith("[") or filename_lower.endswith(".json"):
         try:
-            import json
             data = json.loads(content[:8192])  # partial parse for detection
             if isinstance(data, dict):
                 if "SecurityGroups" in data or "GroupId" in data or "IpPermissions" in data:
@@ -115,6 +101,11 @@ def detect_vendor(content: str, filename: str) -> str | None:
     ):
         return "fortinet"
 
+    # Text-based: Cisco FTD (check before ASA — FTD has ASA-style ACLs too)
+    if any(k in content_lower for k in ("access-control-policy", "firepower threat defense",
+                                         "firepower-module", "intrusion-policy")):
+        return "ftd"
+
     # Text-based: Cisco ASA
     if "access-list" in content_lower and any(k in content_lower for k in ("permit", "deny")):
         return "asa"
@@ -128,9 +119,21 @@ def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bo
     is_xml  = content.strip().startswith("<") or filename.lower().endswith(".xml")
     is_json = content.strip().startswith(("{", "[")) or filename.lower().endswith(".json")
 
-    if vendor == "asa":
+    if vendor == "ftd":
+        if is_xml or is_json:
+            return False, "Cisco FTD LINA configs are text-based, but this file appears to be XML or JSON."
+        # FTD configs may or may not have access-list; require at least some Cisco CLI content
+        if not any(k in content_lower for k in ("access-list", "access-control-policy",
+                                                  "threat-detection", "intrusion-policy",
+                                                  "interface", "firepower")):
+            return False, "No recognizable Cisco FTD configuration markers found. Check vendor selection."
+
+    elif vendor == "asa":
         if is_xml or is_json:
             return False, "Cisco configs are text-based, but this file appears to be XML or JSON."
+        # If the file actually looks like FTD, upgrade silently
+        if is_ftd_config(content):
+            return True, ""  # will be re-routed to ftd in run_audit
         if "access-list" not in content_lower:
             return False, "No Cisco access-list statements found. Check vendor selection."
 
@@ -166,124 +169,50 @@ def validate_vendor_format(content: str, filename: str, vendor: str) -> tuple[bo
     return True, ""
 
 
-def _sort_findings(findings: list) -> list:
-    def priority(f):
-        msg = _finding_msg(f)
-        is_comp = any(x in msg for x in ("PCI-", "CIS-", "NIST-"))
-        if "[HIGH]"   in msg and not is_comp:
-            return 0
-        if "[MEDIUM]" in msg and not is_comp:
-            return 1
-        if "HIGH"     in msg and is_comp:
-            return 2
-        if "MEDIUM"   in msg and is_comp:
-            return 3
-        return 4
-    return sorted(findings, key=priority)
+# ── Hostname extraction ───────────────────────────────────────────────────────
 
+def extract_hostname(vendor: str, content: str) -> str | None:
+    """Try to extract the device hostname from a config file."""
+    try:
+        if vendor in ("asa", "ftd"):
+            m = re.search(r"^hostname\s+(\S+)", content, re.MULTILINE)
+            return m.group(1) if m else None
 
-# ── ASA audit helpers ─────────────────────────────────────────────────────────
+        if vendor == "paloalto":
+            root = ET.fromstring(content)
+            el = root.find(".//devices/entry/deviceconfig/system/hostname")
+            return el.text.strip() if el is not None and el.text else None
 
-def _check_any_any(parse):
-    return [
-        _f("HIGH", "exposure",
-           f"[HIGH] Overly permissive rule found: {r.text.strip()}",
-           "Restrict source and destination to specific IP ranges. "
-           "Remove or scope down any/any permit rules to enforce least-privilege access.")
-        for r in parse.find_objects(r"access-list.*permit.*any any")
-    ]
+        if vendor == "fortinet":
+            block = re.search(r"config system global(.*?)end", content, re.DOTALL)
+            if block:
+                m = re.search(r'set hostname\s+"?([^"\n]+)"?', block.group(1))
+                return m.group(1).strip().strip('"') if m else None
+            return None
 
+        if vendor == "pfsense":
+            root = ET.fromstring(content)
+            el = root.find("system/hostname")
+            return el.text.strip() if el is not None and el.text else None
 
-def _check_missing_logging(parse):
-    return [
-        _f("MEDIUM", "logging",
-           f"[MEDIUM] Permit rule missing logging: {r.text.strip()}",
-           "Add the 'log' keyword to all permit rules. "
-           "Without logging, permitted traffic produces no syslog entries for monitoring.")
-        for r in parse.find_objects(r"access-list.*permit") if "log" not in r.text
-    ]
+        if vendor == "aws":
+            data = json.loads(content)
+            groups = data if isinstance(data, list) else data.get("SecurityGroups", [data])
+            if groups:
+                for t in groups[0].get("Tags", []):
+                    if t.get("Key") == "Name":
+                        return t["Value"]
+                return groups[0].get("GroupName")
 
+        if vendor == "azure":
+            data = json.loads(content)
+            items = data.get("value", [data]) if isinstance(data, dict) else data
+            if items:
+                return items[0].get("name")
 
-def _check_deny_all(parse):
-    if parse.find_objects(r"access-list.*deny ip any any"):
-        return []
-    return [_f(
-        "HIGH", "hygiene",
-        "[HIGH] No explicit deny-all rule found at end of ACL",
-        "Add an explicit 'access-list <name> deny ip any any log' at the end of each ACL. "
-        "Relying on implicit deny produces no log entries and is not auditable."
-    )]
-
-
-def _check_redundant_rules(parse):
-    findings, seen = [], []
-    for rule in parse.find_objects(r"access-list.*permit"):
-        text_clean = rule.text.strip().lower().replace(" log", "").strip()
-        if text_clean in seen:
-            findings.append(_f(
-                "MEDIUM", "redundancy",
-                f"[MEDIUM] Redundant rule detected: {rule.text.strip()}",
-                "Remove duplicate ACL entries to keep the access-list clean and auditable. "
-                "Redundant rules indicate configuration drift and complicate change management."
-            ))
-        else:
-            seen.append(text_clean)
-    return findings
-
-
-def _check_telnet_asa(parse):
-    """Flag Telnet management access configured on the ASA."""
-    return [
-        _f("MEDIUM", "protocol",
-           f"[MEDIUM] Telnet management access configured: {r.text.strip()}",
-           "Disable Telnet management (no telnet ...) and enforce SSH. "
-           "Telnet transmits all data including credentials in cleartext.")
-        for r in parse.find_objects(r"^telnet\s")
-    ]
-
-
-def _check_icmp_any_asa(parse):
-    """Flag ACL entries that allow unrestricted ICMP."""
-    return [
-        _f("MEDIUM", "exposure",
-           f"[MEDIUM] Unrestricted ICMP permit rule: {r.text.strip()}",
-           "Restrict ICMP to specific source ranges or permit only echo-reply, "
-           "unreachable, and time-exceeded message types needed for diagnostics.")
-        for r in parse.find_objects(r"access-list.*permit icmp any any")
-    ]
-
-
-def _audit_asa(filepath):
-    parse = CiscoConfParse(filepath, ignore_blank_lines=False)
-    findings = (
-        _check_any_any(parse)
-        + _check_missing_logging(parse)
-        + _check_deny_all(parse)
-        + _check_redundant_rules(parse)
-        + _check_telnet_asa(parse)
-        + _check_icmp_any_asa(parse)
-    )
-    return findings, parse
-
-
-def _build_summary(findings):
-    def _count(tag):
-        return len([f for f in findings if tag in _finding_msg(f)])
-    high   = [f for f in findings if "[HIGH]"   in _finding_msg(f) and not any(x in _finding_msg(f) for x in ["PCI-", "CIS-", "NIST-"])]
-    medium = [f for f in findings if "[MEDIUM]" in _finding_msg(f) and not any(x in _finding_msg(f) for x in ["PCI-", "CIS-", "NIST-"])]
-    score  = max(0, 100 - len(high) * 10 - len(medium) * 3)
-    return {
-        "high":        len(high),
-        "medium":      len(medium),
-        "pci_high":    _count("PCI-HIGH"),
-        "pci_medium":  _count("PCI-MEDIUM"),
-        "cis_high":    _count("CIS-HIGH"),
-        "cis_medium":  _count("CIS-MEDIUM"),
-        "nist_high":   _count("NIST-HIGH"),
-        "nist_medium": _count("NIST-MEDIUM"),
-        "total":       len(findings),
-        "score":       score,
-    }
+    except Exception:
+        pass
+    return None
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────
@@ -324,28 +253,19 @@ def run_audit():
         os.remove(temp_path)
         return jsonify({"error": "Could not determine vendor. Please select one manually."}), 400
 
+    # When user selects "Cisco" (asa) manually, check if file is actually FTD
+    if vendor == "asa" and is_ftd_config(sample):
+        vendor = "ftd"
+
+    detected_hostname = extract_hostname(vendor, sample)
+
     is_valid, validation_msg = validate_vendor_format(sample, upload.filename, vendor)
     if not is_valid:
         os.remove(temp_path)
         return jsonify({"error": f"Wrong vendor selected ({VENDOR_DISPLAY.get(vendor, vendor)}): {validation_msg}"}), 400
 
     try:
-        findings    = []
-        extra_data  = None
-        parse       = None
-
-        if vendor == "asa":
-            findings, parse = _audit_asa(temp_path)
-        elif vendor == "paloalto":
-            findings = audit_paloalto(temp_path)
-        elif vendor == "fortinet":
-            findings, extra_data = audit_fortinet(temp_path)
-        elif vendor == "pfsense":
-            findings, extra_data = audit_pfsense(temp_path)
-        elif vendor == "aws":
-            findings, extra_data = audit_aws_sg(temp_path)
-        elif vendor == "azure":
-            findings, extra_data = audit_azure_nsg(temp_path)
+        findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
         # Compliance checks (license-gated; not applicable for AWS/Azure)
         license_warning = None
@@ -359,28 +279,8 @@ def run_audit():
                     "Once purchased, enter your key using the Licensed/Unlicensed badge in the top-right corner."
                 )
             else:
-                fn_map = {}
-                if vendor == "asa":
-                    fn_map = {"cis": check_cis_compliance, "pci": check_pci_compliance, "nist": check_nist_compliance}
-                    fn = fn_map.get(compliance)
-                    if fn:
-                        findings += [_wrap_compliance(c) for c in fn(parse)]
-                elif vendor == "paloalto":
-                    rules, _ = parse_paloalto(temp_path)
-                    fn_map = {"cis": check_cis_compliance_pa, "pci": check_pci_compliance_pa, "nist": check_nist_compliance_pa}
-                    fn = fn_map.get(compliance)
-                    if fn:
-                        findings += [_wrap_compliance(c) for c in fn(rules)]
-                elif vendor == "fortinet":
-                    fn_map = {"cis": check_cis_compliance_forti, "pci": check_pci_compliance_forti, "nist": check_nist_compliance_forti}
-                    fn = fn_map.get(compliance)
-                    if fn and extra_data is not None:
-                        findings += [_wrap_compliance(c) for c in fn(extra_data)]
-                elif vendor == "pfsense":
-                    fn_map = {"cis": check_cis_compliance_pf, "pci": check_pci_compliance_pf, "nist": check_nist_compliance_pf}
-                    fn = fn_map.get(compliance)
-                    if fn and extra_data is not None:
-                        findings += [_wrap_compliance(c) for c in fn(extra_data)]
+                raw = run_compliance_checks(vendor, compliance, parse, extra_data)
+                findings += [_wrap_compliance(c) for c in raw]
 
         findings = _sort_findings(findings)
         summary  = _build_summary(findings)
@@ -407,13 +307,14 @@ def run_audit():
         )
 
         return jsonify({
-            "findings":          _findings_to_strings(findings),
-            "enriched_findings": findings,
-            "summary":           summary,
-            "report":            report_filename,
-            "license_warning":   license_warning,
-            "detected_vendor":   vendor,
-            "archive_id":        archive_id,
+            "findings":           _findings_to_strings(findings),
+            "enriched_findings":  findings,
+            "summary":            summary,
+            "report":             report_filename,
+            "license_warning":    license_warning,
+            "detected_vendor":    vendor,
+            "detected_hostname":  detected_hostname,
+            "archive_id":         archive_id,
         })
 
     except Exception as e:
@@ -493,8 +394,8 @@ def live_connect():
 
     if not host or not username or not vendor:
         return jsonify({"error": "host, username, and vendor are required"}), 400
-    if vendor not in ("asa", "fortinet", "paloalto"):
-        return jsonify({"error": f"Live SSH not supported for vendor '{vendor}'. Supported: asa, fortinet, paloalto"}), 400
+    if vendor not in ("asa", "ftd", "fortinet", "paloalto"):
+        return jsonify({"error": f"Live SSH not supported for vendor '{vendor}'. Supported: Cisco (ASA/FTD), Fortinet, Palo Alto Networks"}), 400
 
     label = f"{vendor.upper()}@{host}"
 
@@ -511,36 +412,13 @@ def live_connect():
         return jsonify({"error": f"Connection failed: {e}"}), 500
 
     try:
-        findings   = []
-        extra_data = None
-        parse      = None
+        findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
-        if vendor == "asa":
-            findings, parse = _audit_asa(temp_path)
-        elif vendor == "paloalto":
-            findings = audit_paloalto(temp_path)
-        elif vendor == "fortinet":
-            findings, extra_data = audit_fortinet(temp_path)
-
-        if compliance and vendor not in ("aws", "azure"):
+        if compliance:
             licensed, _ = check_license()
             if licensed:
-                if vendor == "asa":
-                    fn_map = {"cis": check_cis_compliance, "pci": check_pci_compliance, "nist": check_nist_compliance}
-                    fn = fn_map.get(compliance)
-                    if fn:
-                        findings += [_wrap_compliance(c) for c in fn(parse)]
-                elif vendor == "paloalto":
-                    rules, _ = parse_paloalto(temp_path)
-                    fn_map = {"cis": check_cis_compliance_pa, "pci": check_pci_compliance_pa, "nist": check_nist_compliance_pa}
-                    fn = fn_map.get(compliance)
-                    if fn:
-                        findings += [_wrap_compliance(c) for c in fn(rules)]
-                elif vendor == "fortinet":
-                    fn_map = {"cis": check_cis_compliance_forti, "pci": check_pci_compliance_forti, "nist": check_nist_compliance_forti}
-                    fn = fn_map.get(compliance)
-                    if fn and extra_data is not None:
-                        findings += [_wrap_compliance(c) for c in fn(extra_data)]
+                raw = run_compliance_checks(vendor, compliance, parse, extra_data)
+                findings += [_wrap_compliance(c) for c in raw]
 
         findings = _sort_findings(findings)
         summary  = _build_summary(findings)
@@ -663,7 +541,182 @@ def activity_clear():
     return jsonify({"cleared": count})
 
 
+# ── Bulk audit ────────────────────────────────────────────────────────────────
+
+@app.route("/bulk_audit", methods=["POST"])
+def bulk_audit():
+    """Audit multiple config files in one request.
+
+    Accepts: multipart/form-data with repeated field ``configs[]``.
+    Optional shared fields: vendor (default auto), compliance, archive (1/0), tag.
+    Returns: JSON list of per-file result objects.
+    """
+    uploads = request.files.getlist("configs[]")
+    if not uploads or all(u.filename == "" for u in uploads):
+        return jsonify({"error": "No config files uploaded"}), 400
+
+    vendor_override = request.form.get("vendor", "auto").strip().lower()
+    compliance      = request.form.get("compliance", "").strip().lower() or None
+    archive_it      = request.form.get("archive") == "1"
+    tag_prefix      = request.form.get("tag", "").strip() or None
+
+    results = []
+
+    for upload in uploads:
+        if upload.filename == "":
+            continue
+
+        suffix    = Path(upload.filename).suffix or ".txt"
+        temp_name = f"{uuid.uuid4()}{suffix}"
+        temp_path = os.path.join(UPLOAD_FOLDER, temp_name)
+        upload.save(temp_path)
+
+        result_entry = {"filename": upload.filename, "status": "error", "findings": [],
+                        "summary": {}, "vendor": None, "archive_id": None, "error": None}
+
+        try:
+            with open(temp_path, "r", errors="ignore") as f:
+                sample = f.read(16384)
+
+            vendor = vendor_override
+            if vendor == "auto":
+                vendor = detect_vendor(sample, upload.filename) or ""
+
+            if vendor not in ALL_VENDORS:
+                result_entry["error"] = "Could not determine vendor"
+                results.append(result_entry)
+                continue
+
+            if vendor == "asa" and is_ftd_config(sample):
+                vendor = "ftd"
+
+            is_valid, validation_msg = validate_vendor_format(sample, upload.filename, vendor)
+            if not is_valid:
+                result_entry["error"] = validation_msg
+                results.append(result_entry)
+                continue
+
+            findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
+
+            if compliance and vendor not in ("aws", "azure"):
+                licensed, _ = check_license()
+                if licensed:
+                    raw = run_compliance_checks(vendor, compliance, parse, extra_data)
+                    findings += [_wrap_compliance(c) for c in raw]
+
+            findings = _sort_findings(findings)
+            summary  = _build_summary(findings)
+
+            archive_id = None
+            if archive_it:
+                tag = f"{tag_prefix}/{upload.filename}" if tag_prefix else upload.filename
+                archive_id, _ = save_audit(
+                    upload.filename, vendor, _findings_to_strings(findings),
+                    summary, config_path=temp_path, tag=tag,
+                )
+
+            log_activity(
+                ACTION_FILE_AUDIT, upload.filename, vendor=vendor, success=True,
+                details={"bulk": True, "total": summary.get("total", 0),
+                         "high": summary.get("high", 0), "archived": archive_id is not None},
+            )
+
+            result_entry.update({
+                "status":          "ok",
+                "vendor":          vendor,
+                "findings":        _findings_to_strings(findings),
+                "enriched_findings": findings,
+                "summary":         summary,
+                "archive_id":      archive_id,
+            })
+
+        except Exception as e:
+            result_entry["error"] = str(e)
+            log_activity(ACTION_FILE_AUDIT, upload.filename, vendor=vendor_override,
+                         success=False, error=str(e), details={"bulk": True})
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+        results.append(result_entry)
+
+    return jsonify(results)
+
+
+# ── Scheduled audits API ───────────────────────────────────────────────────────
+
+@app.route("/schedules", methods=["GET"])
+def schedules_list():
+    return jsonify(list_schedules())
+
+
+@app.route("/schedules", methods=["POST"])
+def schedules_create():
+    data = request.get_json(silent=True) or {}
+    if not data.get("host") or not data.get("username"):
+        return jsonify({"error": "host and username are required"}), 400
+    schedule = create_schedule(data)
+    reload_job(schedule["id"], get_schedule(schedule["id"], include_password=True))
+    return jsonify(schedule), 201
+
+
+@app.route("/schedules/<schedule_id>", methods=["GET"])
+def schedules_get(schedule_id):
+    schedule = get_schedule(schedule_id)
+    if not schedule:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify(schedule)
+
+
+@app.route("/schedules/<schedule_id>", methods=["PUT"])
+def schedules_update(schedule_id):
+    data = request.get_json(silent=True) or {}
+    schedule = update_schedule(schedule_id, data)
+    if not schedule:
+        return jsonify({"error": "Not found"}), 404
+    reload_job(schedule_id, get_schedule(schedule_id, include_password=True))
+    return jsonify(schedule)
+
+
+@app.route("/schedules/<schedule_id>", methods=["DELETE"])
+def schedules_delete(schedule_id):
+    deleted = delete_schedule(schedule_id)
+    if deleted:
+        reload_job(schedule_id, None)  # removes the job from the scheduler
+    return jsonify({"deleted": deleted})
+
+
+@app.route("/schedules/<schedule_id>/run", methods=["POST"])
+def schedules_run_now(schedule_id):
+    """Trigger an immediate on-demand run of a scheduled audit."""
+    schedule = get_schedule(schedule_id)
+    if not schedule:
+        return jsonify({"error": "Not found"}), 404
+    scheduler_run_now(schedule_id)
+    return jsonify({"queued": True, "id": schedule_id})
+
+
+@app.route("/schedules/status", methods=["GET"])
+def schedules_status():
+    return jsonify({"scheduler_available": scheduler_available()})
+
+
 # ── Reports / License ─────────────────────────────────────────────────────────
+
+@app.route("/reports", methods=["GET"])
+def reports_list():
+    """List all saved PDF reports."""
+    reports = []
+    for fname in sorted(os.listdir(REPORTS_FOLDER), reverse=True):
+        if fname.endswith(".pdf"):
+            path = os.path.join(REPORTS_FOLDER, fname)
+            reports.append({
+                "filename": fname,
+                "size":     os.path.getsize(path),
+                "mtime":    os.path.getmtime(path),
+            })
+    return jsonify(reports)
+
 
 @app.route("/reports/<filename>")
 def download_report(filename):
@@ -673,6 +726,17 @@ def download_report(filename):
     if not os.path.exists(path):
         return "Report not found", 404
     return send_file(path, as_attachment=True, download_name=filename)
+
+
+@app.route("/reports/<filename>/view")
+def view_report(filename):
+    """Serve PDF inline for in-browser viewing."""
+    if ".." in filename or "/" in filename:
+        return "Not found", 404
+    path = os.path.join(REPORTS_FOLDER, filename)
+    if not os.path.exists(path):
+        return "Report not found", 404
+    return send_file(path, as_attachment=False, mimetype="application/pdf")
 
 
 @app.route("/license/activate", methods=["POST"])
@@ -694,9 +758,30 @@ def license_status():
     return jsonify({"licensed": licensed, "info": info})
 
 
+# ── Settings API ──────────────────────────────────────────────────────────────
+
+@app.route("/settings", methods=["GET"])
+def settings_get():
+    return jsonify(get_settings())
+
+
+@app.route("/settings", methods=["POST"])
+def settings_save():
+    data = request.get_json(silent=True) or {}
+    saved = save_settings(data)
+    return jsonify(saved)
+
+
 def main():
     port = int(os.environ.get("PORT", 5000))
     app.run(host="0.0.0.0", port=port)
+
+
+# Start scheduler on import — covers both WSGI servers (gunicorn/uwsgi)
+# and direct `flintlock-web` invocation. The scheduler has an internal
+# guard that prevents double-start if this module is reloaded.
+start_scheduler()
+atexit.register(stop_scheduler)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Cisco FTD**: auto-detection, 14 audit checks, SSH pull, diff support; vendor always displays as "Cisco"
- **Bulk audit**: multi-file upload, per-file expandable results with score badges
- **APScheduler bundled**: added to `requirements.txt`, removed graceful-degradation shim and status banner
- **Scheduled SSH audits**: full CRUD, CronTrigger (hourly/daily/weekly), run-now, JSON-backed store
- **HIPAA Security Rule** (45 CFR §164): compliance checks across all 5 vendors
- **Settings tab**: auto-PDF, auto-archive defaults, default compliance framework
- **`audit_engine.py`**: shared module eliminates circular imports; Palo Alto double-parse and 3× compliance fn_map blocks removed
- **Nav simplified 8 → 6 tabs**: "Audit" (single/bulk mode toggle) + "History" (Audit History / Activity Log sub-tabs)
- **Hostname extraction**: `extract_hostname()` parses all 7 vendors; auto-fills Device Tag field if empty after upload
- **PDF in-app view**: `/reports/<name>/view` serves inline alongside download
- **JS**: event delegation for schedules list; `switchAuditMode` / `switchHistorySubTab` functions added; `schedulerStatusBanner` removed

## Test plan

- [ ] Upload ASA/FTD config — verify hostname auto-fills Device Tag; vendor shows "Cisco"
- [ ] Upload Palo Alto XML / Fortinet / pfSense — verify hostname extraction for each
- [ ] Run bulk audit with 2+ files — verify per-file results expand correctly
- [ ] Switch Audit tab to "Bulk" mode and back — verify mode toggle
- [ ] Open History tab — verify Audit History and Activity Log sub-tabs both load
- [ ] Open Schedules tab — verify no APScheduler banner appears
- [ ] Create a schedule, run it via Run Now — check Audit History for result
- [ ] Run compliance check with HIPAA framework — verify findings appear
- [ ] Generate PDF — verify both Download and View PDF links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)