### PR TITLE
Feature: API auth, PEM SSH, REST API, CSP, rate limiting, health endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "fpdf2>=2.7",
     "flask>=3.0",
     "flask-wtf>=1.2",
+    "flask-limiter>=3.5",
     "cryptography>=41.0",
     "paramiko>=3.0",
     "apscheduler>=3.10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ciscoconfparse>=1.9
 fpdf2>=2.7
 flask>=3.0
 flask-wtf>=1.2
+flask-limiter>=3.5
 cryptography>=41.0
 paramiko>=3.0
 apscheduler>=3.10

--- a/src/cashel/juniper.py
+++ b/src/cashel/juniper.py
@@ -407,7 +407,7 @@ def audit_juniper(filepath: str) -> tuple[list[dict], list[dict]]:
         # parse_juniper returned an error string
         return [_f("HIGH", "parse", f"[HIGH] Parse error: {content_or_err}")], []
 
-    content = content_or_err  # parse_juniper returns content on success
+    content: str = content_or_err or ""  # parse_juniper returns content on success
 
     findings: list[dict] = []
     findings += check_system_juniper(content)

--- a/src/cashel/settings.py
+++ b/src/cashel/settings.py
@@ -1,13 +1,7 @@
 """Global application settings — persisted as JSON.
 
-SMTP passwords are encrypted at rest using Fernet (see crypto.py).
+SMTP passwords and API keys are encrypted at rest using Fernet (see crypto.py).
 Legacy plaintext passwords are transparently migrated on next save.
-
-SECURITY ROADMAP NOTES
-━━━━━━━━━━━━━━━━━━━━━━
-Phase 2 — API Key Authentication (pending):
-  Keys to add: ``auth_enabled`` (bool), ``api_key_hash`` (bcrypt/scrypt hash of
-  the admin key), ``session_lifetime_minutes`` (int).
 """
 import json
 import os
@@ -58,6 +52,14 @@ DEFAULTS: dict = {
     # "full"      → return raw exception text (development only)
     "error_detail": "sanitized",
 
+    # ── Authentication ────────────────────────────────────────────────────────
+    # When auth_enabled is True, all web UI and API routes require the API key.
+    # The key is stored encrypted (api_key_enc) and never shown after first
+    # generation — treat it like a password.  Session lifetime controls how long
+    # a browser login is valid (sliding window).
+    "auth_enabled":              False,
+    "session_lifetime_minutes":  480,   # 8 hours default
+
     # ── Syslog ────────────────────────────────────────────────────────────────
     # Forward application events to a remote syslog server for SIEM integration.
     # Protocol: "udp" (RFC 3164, default) or "tcp" (reliable delivery).
@@ -79,6 +81,8 @@ def get_settings() -> dict:
         # Decrypt smtp_password — stored encrypted, exposed in-process as plaintext
         if data.get("smtp_password_enc"):
             merged["smtp_password"] = decrypt(data["smtp_password_enc"])
+        # Decrypt api_key — stored encrypted, never exposed to the template directly
+        merged["api_key"] = decrypt(data["api_key_enc"]) if data.get("api_key_enc") else ""
         return merged
     except (FileNotFoundError, json.JSONDecodeError):
         return dict(DEFAULTS)
@@ -112,13 +116,41 @@ def save_settings(data: dict) -> dict:
         merged["smtp_password_enc"] = encrypt(smtp_pw)
     elif "smtp_password_enc" not in merged:
         merged["smtp_password_enc"] = ""
-    # Don't store plaintext password key in the file
     merged.pop("smtp_password", None)
+
+    # api_key is managed separately via /settings/generate-api-key; never passed
+    # through save_settings (it would be overwritten to empty on every settings save).
+    # Remove it from the dict — the encrypted api_key_enc is preserved from disk.
+    merged.pop("api_key", None)
+
+    # Preserve existing api_key_enc from disk if not being explicitly updated
+    try:
+        with open(SETTINGS_FILE) as _f:
+            _existing = json.load(_f)
+        if _existing.get("api_key_enc") and "api_key_enc" not in merged:
+            merged["api_key_enc"] = _existing["api_key_enc"]
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
 
     os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
     with open(SETTINGS_FILE, "w") as f:
         json.dump(merged, f, indent=2)
 
-    # Return with decrypted password so callers get the expected key
+    # Return with decrypted values so callers get the expected keys
     merged["smtp_password"] = smtp_pw
     return merged
+
+
+def save_api_key(plaintext_key: str) -> None:
+    """Encrypt and persist the API key. Separate from save_settings so it is
+    never accidentally overwritten by a settings form submission."""
+    from .crypto import encrypt as _enc
+    try:
+        with open(SETTINGS_FILE) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = {}
+    data["api_key_enc"] = _enc(plaintext_key)
+    os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+    with open(SETTINGS_FILE, "w") as f:
+        json.dump(data, f, indent=2)

--- a/src/cashel/ssh_connector.py
+++ b/src/cashel/ssh_connector.py
@@ -43,7 +43,9 @@ def _read_until_idle(channel, timeout=RECV_TIMEOUT, idle_secs=1.5):
 
 
 def _make_client(host, port, username, password, timeout,
-                  host_key_policy: str = "warn"):
+                  host_key_policy: str = "warn",
+                  pem_key_path: str | None = None,
+                  pem_passphrase: str | None = None):
     """Create and connect a Paramiko SSH client.
 
     *host_key_policy* controls how unknown host keys are handled:
@@ -55,6 +57,10 @@ def _make_client(host, port, username, password, timeout,
                        AutoAddPolicy).
       ``"auto_add"`` — AutoAddPolicy: silently accept any host key.  Insecure
                        (MITM-vulnerable); available only for isolated lab use.
+
+    *pem_key_path* — path to a PEM private key file (RSA, ECDSA, or Ed25519).
+      When provided, key-based authentication is used instead of a password.
+    *pem_passphrase* — optional passphrase for an encrypted PEM key.
     """
     client = paramiko.SSHClient()
     # Load system + user known_hosts so strict/warn modes work with pre-approved keys.
@@ -70,18 +76,45 @@ def _make_client(host, port, username, password, timeout,
     }
     policy_cls = _policy_map.get(host_key_policy, paramiko.WarningPolicy)
     client.set_missing_host_key_policy(policy_cls())
-    client.connect(
-        host, port=port, username=username, password=password,
-        timeout=timeout, look_for_keys=False, allow_agent=False,
-    )
+
+    connect_kwargs: dict = {
+        "hostname": host,
+        "port": port,
+        "username": username,
+        "timeout": timeout,
+        "look_for_keys": False,
+        "allow_agent": False,
+    }
+
+    if pem_key_path:
+        pp = pem_passphrase.encode() if pem_passphrase else None
+        pkey = None
+        for key_cls in (paramiko.RSAKey, paramiko.ECDSAKey, paramiko.Ed25519Key):
+            try:
+                pkey = key_cls.from_private_key_file(pem_key_path, password=pp)
+                break
+            except (paramiko.SSHException, ValueError):
+                continue
+        if pkey is None:
+            raise ValueError(
+                "Could not load PEM key. Ensure the file is a valid RSA, ECDSA, "
+                "or Ed25519 private key and that the passphrase is correct."
+            )
+        connect_kwargs["pkey"] = pkey
+    else:
+        connect_kwargs["password"] = password
+
+    client.connect(**connect_kwargs)
     return client
 
 
 # ── Cisco ASA ─────────────────────────────────────────────────────────────────
 
-def _pull_asa(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_asa(host, port, username, password, timeout, host_key_policy="warn",
+              pem_key_path=None, pem_passphrase=None):
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         ch = client.invoke_shell()
         time.sleep(1)
@@ -97,9 +130,11 @@ def _pull_asa(host, port, username, password, timeout, host_key_policy="warn"):
 
 # ── Fortinet ──────────────────────────────────────────────────────────────────
 
-def _pull_fortinet(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_fortinet(host, port, username, password, timeout, host_key_policy="warn",
+                   pem_key_path=None, pem_passphrase=None):
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         ch = client.invoke_shell()
         time.sleep(1)
@@ -115,10 +150,12 @@ def _pull_fortinet(host, port, username, password, timeout, host_key_policy="war
 
 # ── Palo Alto Networks ────────────────────────────────────────────────────────
 
-def _pull_paloalto(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_paloalto(host, port, username, password, timeout, host_key_policy="warn",
+                   pem_key_path=None, pem_passphrase=None):
     """Pull running config via PA CLI SSH command."""
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         stdin, stdout, stderr = client.exec_command(
             "show config running", timeout=timeout
@@ -134,21 +171,25 @@ def _pull_paloalto(host, port, username, password, timeout, host_key_policy="war
 # ── Cisco FTD ─────────────────────────────────────────────────────────────────
 # FTD LINA CLI accepts the same commands as ASA for pulling the running config.
 
-def _pull_ftd(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_ftd(host, port, username, password, timeout, host_key_policy="warn",
+              pem_key_path=None, pem_passphrase=None):
     """Pull FTD running config via LINA CLI (same as ASA)."""
-    return _pull_asa(host, port, username, password, timeout, host_key_policy)
+    return _pull_asa(host, port, username, password, timeout, host_key_policy,
+                     pem_key_path, pem_passphrase)
 
 
 # ── Juniper SRX ───────────────────────────────────────────────────────────────
 
-def _pull_juniper(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_juniper(host, port, username, password, timeout, host_key_policy="warn",
+                  pem_key_path=None, pem_passphrase=None):
     """Pull Juniper SRX config in set-format via Junos CLI SSH shell.
 
     Disables the screen-length pager first so the full config is returned
     without interactive ``---more---`` prompts.
     """
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         ch = client.invoke_shell()
         time.sleep(2)
@@ -164,14 +205,16 @@ def _pull_juniper(host, port, username, password, timeout, host_key_policy="warn
 
 # ── pfSense ───────────────────────────────────────────────────────────────────
 
-def _pull_pfsense(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_pfsense(host, port, username, password, timeout, host_key_policy="warn",
+                  pem_key_path=None, pem_passphrase=None):
     """Pull pfSense config.xml via SSH exec_command.
 
     Requires the SSH user to have shell access (not just the menu).
     The config file is at /conf/config.xml on all modern pfSense releases.
     """
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         stdin, stdout, stderr = client.exec_command(
             "cat /conf/config.xml", timeout=timeout
@@ -184,14 +227,16 @@ def _pull_pfsense(host, port, username, password, timeout, host_key_policy="warn
 
 # ── iptables (Linux) ──────────────────────────────────────────────────────────
 
-def _pull_iptables(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_iptables(host, port, username, password, timeout, host_key_policy="warn",
+                   pem_key_path=None, pem_passphrase=None):
     """Pull iptables rules via SSH using iptables-save.
 
     Tries the direct command first; falls back to sudo if the account is not root.
     The connecting user must have password-less sudo or run as root.
     """
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         stdin, stdout, stderr = client.exec_command(
             "iptables-save 2>/dev/null || sudo iptables-save 2>/dev/null",
@@ -205,13 +250,15 @@ def _pull_iptables(host, port, username, password, timeout, host_key_policy="war
 
 # ── nftables (Linux) ──────────────────────────────────────────────────────────
 
-def _pull_nftables(host, port, username, password, timeout, host_key_policy="warn"):
+def _pull_nftables(host, port, username, password, timeout, host_key_policy="warn",
+                   pem_key_path=None, pem_passphrase=None):
     """Pull nftables ruleset via SSH using nft list ruleset.
 
     Tries the direct command first; falls back to sudo if needed.
     """
     _require_paramiko()
-    client = _make_client(host, port, username, password, timeout, host_key_policy)
+    client = _make_client(host, port, username, password, timeout, host_key_policy,
+                          pem_key_path, pem_passphrase)
     try:
         stdin, stdout, stderr = client.exec_command(
             "nft list ruleset 2>/dev/null || sudo nft list ruleset 2>/dev/null",
@@ -248,18 +295,24 @@ _PULLERS = {
 
 
 def connect_and_pull(vendor, host, port, username, password, timeout=30,
-                     upload_folder=None, host_key_policy: str = "warn"):
+                     upload_folder=None, host_key_policy: str = "warn",
+                     pem_key_path: str | None = None,
+                     pem_passphrase: str | None = None):
     """
     Connect to a live device, pull its running config, and save to a temp file.
 
     Returns (temp_file_path, raw_content_str).
     Raises RuntimeError / paramiko exceptions on failure.
+
+    *pem_key_path* — path to a PEM private key file for key-based auth.
+    *pem_passphrase* — optional passphrase for the PEM key.
     """
     puller = _PULLERS.get(vendor)
     if puller is None:
         raise ValueError(f"Live SSH not supported for vendor: {vendor}")
 
-    content = puller(host, int(port), username, password, int(timeout), host_key_policy)
+    content = puller(host, int(port), username, password, int(timeout),
+                     host_key_policy, pem_key_path, pem_passphrase)
 
     if not content or len(content.strip()) < 50:
         raise RuntimeError(

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -6,8 +6,8 @@
   <meta name="csrf-token" content="{{ csrf_token() }}" />
   <title>Cashel &mdash; Firewall Audit</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-  <script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" nonce="{{ g.csp_nonce }}"></script>
+  <script nonce="{{ g.csp_nonce }}">
     (function () {
       const t = localStorage.getItem("cashel-theme") || "auto";
       document.documentElement.setAttribute("data-theme", t);
@@ -367,9 +367,30 @@
               <label for="connUser">Username</label>
               <input type="text" id="connUser" name="username" placeholder="admin" autocomplete="off" />
             </div>
-            <div class="form-group">
+            <div class="form-group" style="grid-column:1/-1">
+              <label>Authentication Method</label>
+              <div style="display:flex;gap:1.5rem;margin-top:0.35rem">
+                <label style="display:flex;align-items:center;gap:0.4rem;cursor:pointer">
+                  <input type="radio" name="auth_method" value="password" id="authMethodPassword" checked />
+                  <span>Password</span>
+                </label>
+                <label style="display:flex;align-items:center;gap:0.4rem;cursor:pointer">
+                  <input type="radio" name="auth_method" value="pem_key" id="authMethodPem" />
+                  <span>PEM Key File</span>
+                </label>
+              </div>
+            </div>
+            <div class="form-group" id="connPassGroup">
               <label for="connPass">Password</label>
               <input type="password" id="connPass" name="password" placeholder="&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;" autocomplete="current-password" />
+            </div>
+            <div class="form-group hidden" id="connPemGroup">
+              <label for="connPemKey">PEM Key File</label>
+              <input type="file" id="connPemKey" name="pem_key" accept=".pem,.key" />
+            </div>
+            <div class="form-group hidden" id="connPemPassGroup">
+              <label for="connPemPassphrase">Key Passphrase <span class="optional">(if encrypted)</span></label>
+              <input type="password" id="connPemPassphrase" name="pem_passphrase" autocomplete="new-password" />
             </div>
             <div class="form-group">
               <label for="connCompliance">Compliance <span class="optional">(licensed)</span></label>
@@ -669,6 +690,11 @@
             Email (SMTP)
           </button>
 
+          <button class="settings-nav-item" data-pane="auth">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="7" width="10" height="8" rx="1.5"/><path d="M5 7V5a3 3 0 0 1 6 0v2"/><circle cx="8" cy="11" r="1" fill="currentColor" stroke="none"/></svg>
+            Authentication
+          </button>
+
           <button class="settings-nav-item" data-pane="security">
             <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 1.5L2 4v4.5c0 3.5 2.5 6.7 6 7.5 3.5-.8 6-4 6-7.5V4L8 1.5z"/><path d="M5.5 8l2 2 3-3"/></svg>
             Security
@@ -778,8 +804,50 @@
             </div>
           </div>
 
+          <!-- Authentication pane -->
+          <div class="settings-pane hidden" id="spane-auth">
+            <div class="settings-pane-header">
+              <h2 class="settings-pane-title">Authentication</h2>
+              <p class="settings-pane-desc">Protect the Cashel web UI and API with an API key. When enabled, all routes require the key — via browser login or <code>X-API-Key</code> header for CI/CD clients.</p>
+            </div>
+
+            <div class="settings-group">
+              <h3 class="settings-group-title">Access Control</h3>
+              <label class="settings-row">
+                <span class="settings-row-label">Enable Authentication</span>
+                <input type="checkbox" class="settings-toggle" id="setting-auth-enabled" />
+              </label>
+              <div class="settings-row">
+                <span class="settings-row-label">Session Lifetime</span>
+                <div style="display:flex;align-items:center;gap:0.5rem">
+                  <input type="number" id="setting-session-lifetime" class="settings-input" style="width:80px" min="5" max="10080" />
+                  <span class="text-muted" style="font-size:0.82rem">minutes</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-group">
+              <h3 class="settings-group-title">API Key</h3>
+              <div class="settings-row">
+                <span class="settings-row-label">Current Key</span>
+                <span class="text-muted" id="authKeyHint" style="font-family:monospace;font-size:0.88rem">not set</span>
+              </div>
+              <div style="margin-top:0.75rem;display:flex;gap:0.75rem;flex-wrap:wrap">
+                <button class="btn-secondary" id="btnGenerateKey">Generate New Key</button>
+              </div>
+              <div id="authNewKeyBox" class="hidden" style="margin-top:1rem;background:var(--card-bg);border:1px solid var(--accent);border-radius:8px;padding:1rem">
+                <p style="font-size:0.82rem;color:var(--high);font-weight:600;margin-bottom:0.5rem">&#9888; Copy this key now — it will not be shown again.</p>
+                <div style="display:flex;align-items:center;gap:0.5rem">
+                  <code id="authNewKeyVal" style="flex:1;padding:0.5rem;background:var(--input-bg);border-radius:4px;word-break:break-all;font-size:0.88rem"></code>
+                  <button class="btn-secondary" onclick="navigator.clipboard.writeText(document.getElementById('authNewKeyVal').textContent).then(()=>this.textContent='Copied!').catch(()=>this.textContent='Error')">Copy</button>
+                </div>
+              </div>
+              <p class="settings-pane-desc" style="margin-top:0.75rem">Use this key in the <code>X-API-Key</code> header for CLI or CI/CD access:<br><code>curl -H "X-API-Key: csh_..." https://your-cashel/api/v1/audit</code></p>
+            </div>
+          </div>
+
           <!-- Security pane -->
-          <div class="settings-pane" id="spane-security">
+          <div class="settings-pane hidden" id="spane-security">
             <div class="settings-pane-header">
               <h2 class="settings-pane-title">Security</h2>
               <p class="settings-pane-desc">Controls for SSH host verification, outbound webhook restrictions, and error reporting exposure.</p>
@@ -899,7 +967,7 @@
     <p>Cashel v1.2 &mdash; Firewall Security Auditor</p>
   </footer>
 
-  <script>
+  <script nonce="{{ g.csp_nonce }}">
   // ═══════════════════════════════════════════════════════════════ THEME ══
   const html = document.documentElement;
   const themeIcon = document.getElementById("themeIcon");
@@ -1519,11 +1587,23 @@
   }
 
   // ════════════════════════════════════════════════════ LIVE CONNECT ══════
+  // PEM auth method toggle
+  document.querySelectorAll('input[name="auth_method"]').forEach(r => {
+    r.addEventListener("change", () => {
+      const isPem = document.getElementById("authMethodPem").checked;
+      document.getElementById("connPassGroup").classList.toggle("hidden", isPem);
+      document.getElementById("connPemGroup").classList.toggle("hidden", !isPem);
+      document.getElementById("connPemPassGroup").classList.toggle("hidden", !isPem);
+    });
+  });
+
   document.getElementById("connectForm").addEventListener("submit", async function (e) {
     e.preventDefault();
     setLoading("connectBtn", "connectText", "connectSpinner", "Connecting\u2026", true);
     try {
-      const res  = await fetch("/connect", { method: "POST", body: new URLSearchParams(new FormData(this)) });
+      // Use raw FormData so PEM file uploads are included
+      const formData = new FormData(this);
+      const res  = await fetch("/connect", { method: "POST", body: formData });
       const data = await res.json();
       if (data.error) {
         document.getElementById("connectResults").classList.remove("hidden");
@@ -2182,6 +2262,11 @@
     document.getElementById("setting-syslog-port").value             = appSettings.syslog_port          || 514;
     document.getElementById("setting-syslog-protocol").value         = appSettings.syslog_protocol      || "udp";
     document.getElementById("setting-syslog-facility").value         = appSettings.syslog_facility      || "local0";
+    // Auth settings
+    document.getElementById("setting-auth-enabled").checked          = !!appSettings.auth_enabled;
+    document.getElementById("setting-session-lifetime").value        = appSettings.session_lifetime_minutes || 480;
+    const hint = appSettings.api_key_hint || (appSettings.api_key_set ? "(key set — hint unavailable)" : "not set");
+    document.getElementById("authKeyHint").textContent               = hint;
   }
 
   // ── Settings sidebar navigation ──────────────────────────────────────────
@@ -2226,6 +2311,9 @@
       syslog_port:          parseInt(document.getElementById("setting-syslog-port").value) || 514,
       syslog_protocol:      document.getElementById("setting-syslog-protocol").value,
       syslog_facility:      document.getElementById("setting-syslog-facility").value,
+      // Auth settings
+      auth_enabled:             document.getElementById("setting-auth-enabled").checked,
+      session_lifetime_minutes: parseInt(document.getElementById("setting-session-lifetime").value) || 480,
       ...(document.getElementById("setting-smtp-password").value
           ? {smtp_password: document.getElementById("setting-smtp-password").value}
           : {}),
@@ -2280,6 +2368,27 @@
     } finally {
       btn.disabled    = false;
       btn.textContent = "✉ Test SMTP";
+    }
+  });
+
+  // ══════════════════════════════════════════════ GENERATE API KEY ══
+  document.getElementById("btnGenerateKey").addEventListener("click", async function () {
+    if (!confirm("Generate a new API key? The current key (if any) will be invalidated immediately.")) return;
+    this.disabled = true;
+    try {
+      const res  = await fetch("/settings/generate-api-key", { method: "POST" });
+      const data = await res.json();
+      if (!data.ok) {
+        alert("Failed to generate key: " + (data.error || "Unknown error"));
+        return;
+      }
+      document.getElementById("authNewKeyVal").textContent = data.api_key;
+      document.getElementById("authNewKeyBox").classList.remove("hidden");
+      document.getElementById("authKeyHint").textContent   = data.api_key_hint || data.api_key.slice(0, 12) + "…";
+    } catch (err) {
+      alert("Request failed: " + err.message);
+    } finally {
+      this.disabled = false;
     }
   });
 

--- a/src/cashel/templates/login.html
+++ b/src/cashel/templates/login.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="csrf-token" content="{{ csrf_token() }}" />
+  <title>Cashel — Login</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <style>
+    .login-wrap {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      background: var(--bg);
+    }
+    .login-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 380px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.3);
+    }
+    .login-logo {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--accent);
+      margin-bottom: 0.25rem;
+    }
+    .login-sub {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 2rem;
+    }
+    .login-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      margin-bottom: 1.25rem;
+    }
+    .login-field label {
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .login-field input {
+      width: 100%;
+      padding: 0.65rem 0.85rem;
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 0.95rem;
+      font-family: monospace;
+      box-sizing: border-box;
+    }
+    .login-field input:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+    .login-btn {
+      width: 100%;
+      padding: 0.7rem;
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    .login-btn:hover { opacity: 0.88; }
+    .login-error {
+      background: var(--finding-high-bg);
+      border: 1px solid var(--high);
+      color: var(--high);
+      border-radius: 6px;
+      padding: 0.6rem 0.85rem;
+      font-size: 0.88rem;
+      margin-bottom: 1.25rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-wrap">
+    <div class="login-card">
+      <div class="login-logo">&#128274; Cashel</div>
+      <div class="login-sub">Firewall Configuration Auditor</div>
+
+      {% if error %}
+      <div class="login-error">{{ error }}</div>
+      {% endif %}
+
+      <form method="POST" action="{{ url_for('login_post', next=request.args.get('next', '')) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <div class="login-field">
+          <label for="api_key">API Key</label>
+          <input type="password" id="api_key" name="api_key"
+                 placeholder="csh_…" autocomplete="current-password"
+                 autofocus required />
+        </div>
+        <button type="submit" class="login-btn">Sign In</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/cashel/web.py
+++ b/src/cashel/web.py
@@ -1,13 +1,21 @@
 import atexit
+import importlib.metadata
 import json
 import logging as _logging
 import os
 import re
+import secrets
+import time
 import uuid
 from defusedxml import ElementTree as ET
 from pathlib import Path
-from flask import Flask, render_template, request, jsonify, send_file
+from flask import (
+    Flask, Blueprint, render_template, request, jsonify,
+    send_file, session, redirect, url_for, g,
+)
 from flask_wtf.csrf import CSRFProtect
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 from .license import check_license, activate_license, deactivate_license, mask_key
 from .ftd import is_ftd_config
@@ -24,7 +32,7 @@ from .activity_log import (
     log_activity, list_activity, delete_activity_entry, clear_activity,
     ACTION_FILE_AUDIT, ACTION_SSH_CONNECT, ACTION_CONFIG_DIFF,
 )
-from .settings import get_settings, save_settings
+from .settings import get_settings, save_settings, save_api_key
 from .schedule_store import (
     list_schedules, get_schedule, create_schedule,
     update_schedule, delete_schedule, ScheduleValidationError,
@@ -46,21 +54,44 @@ for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER, ACTIVITY_FOLDER):
 # Settings folder is created lazily by settings.py on first save
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
-app.config["SECRET_KEY"] = os.environ.get("CASHEL_SECRET", "change-me-in-production")
-app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10 MB upload limit
+app.config["SECRET_KEY"]              = os.environ.get("CASHEL_SECRET", "change-me-in-production")
+app.config["MAX_CONTENT_LENGTH"]      = 50 * 1024 * 1024   # 50 MB total request cap
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"]   = os.environ.get("CASHEL_SECURE_COOKIES", "false").lower() == "true"
+
 csrf = CSRFProtect(app)
+
+limiter = Limiter(
+    app=app,
+    key_func=get_remote_address,
+    default_limits=[],
+    storage_uri="memory://",
+)
+
+_start_time = time.time()
+_MAX_FILE_BYTES = 5 * 1024 * 1024   # 5 MB per-file limit enforced in routes
+
+# ── REST API blueprint (CSRF-exempt; auth via X-API-Key) ──────────────────────
+api_bp = Blueprint("api_v1", __name__, url_prefix="/api/v1")
+csrf.exempt(api_bp)
+
+
+# ── CSP nonce ─────────────────────────────────────────────────────────────────
+
+@app.before_request
+def _assign_csp_nonce():
+    g.csp_nonce = secrets.token_urlsafe(16)
 
 
 # ── HTTP security headers ─────────────────────────────────────────────────────
-# Applied to every response.  HSTS is intentionally omitted here because
-# Cashel may run over plain HTTP in local/dev setups; enable it at the
-# reverse-proxy layer when deploying with TLS.
-# CSP is omitted pending a full frontend audit (inline scripts + CDN assets
-# need to be enumerated first) — tracked in the security roadmap Phase 2.
+# HSTS is intentionally omitted — enable at the reverse-proxy layer when
+# deploying with TLS.
 
 @app.after_request
 def _add_security_headers(response):
-    response.headers.setdefault("X-Frame-Options",        "SAMEORIGIN")
+    nonce = getattr(g, "csp_nonce", "")
+    response.headers.setdefault("X-Frame-Options",        "DENY")
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
     response.headers.setdefault("X-XSS-Protection",       "1; mode=block")
     response.headers.setdefault("Referrer-Policy",        "strict-origin-when-cross-origin")
@@ -68,7 +99,74 @@ def _add_security_headers(response):
         "Permissions-Policy",
         "geolocation=(), microphone=(), camera=()",
     )
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        f"default-src 'self'; "
+        f"script-src 'nonce-{nonce}' https://cdn.jsdelivr.net; "
+        f"style-src 'self' 'unsafe-inline'; "
+        f"img-src 'self' data:; "
+        f"connect-src 'self'; "
+        f"font-src 'self'; "
+        f"object-src 'none'; "
+        f"frame-ancestors 'none';",
+    )
     return response
+
+
+# ── Error handlers ────────────────────────────────────────────────────────────
+
+@app.errorhandler(413)
+def request_too_large(_e):
+    return jsonify({"error": "Upload too large. Maximum file size is 5 MB per file."}), 413
+
+
+@app.errorhandler(429)
+def rate_limit_exceeded(e):
+    return jsonify({"error": "Rate limit exceeded. Please slow down.", "retry_after": str(getattr(e, "retry_after", ""))}), 429
+
+
+# ── Authentication middleware ─────────────────────────────────────────────────
+
+_AUTH_EXEMPT_ENDPOINTS = {"login", "login_post", "logout", "health", "static"}
+
+
+@app.before_request
+def _require_auth():
+    settings = get_settings()
+    if not settings.get("auth_enabled"):
+        return
+
+    if request.endpoint in _AUTH_EXEMPT_ENDPOINTS:
+        return
+
+    # API key auth (header or query param) — used by CLI/CI clients
+    api_key_header = (
+        request.headers.get("X-API-Key") or
+        request.args.get("api_key")
+    )
+    if api_key_header:
+        stored = settings.get("api_key", "")
+        if stored and secrets.compare_digest(api_key_header, stored):
+            g.auth_method = "api_key"
+            return
+        if request.path.startswith("/api/"):
+            return jsonify({"ok": False, "data": None, "error": "Invalid API key."}), 401
+        return jsonify({"error": "Invalid API key."}), 401
+
+    # Session auth (browser)
+    if session.get("authenticated"):
+        lifetime = settings.get("session_lifetime_minutes", 480)
+        if time.time() - session.get("last_seen", 0) < lifetime * 60:
+            session["last_seen"] = time.time()
+            g.auth_method = "session"
+            return
+        session.clear()
+
+    # Not authenticated
+    if request.path.startswith("/api/"):
+        return jsonify({"ok": False, "data": None, "error": "Authentication required."}), 401
+    next_url = request.url if request.method == "GET" else None
+    return redirect(url_for("login", next=next_url))
 
 
 # ── Error response helper ─────────────────────────────────────────────────────
@@ -350,6 +448,54 @@ def extract_hostname(vendor: str, content: str) -> str | None:
 
 # ── Routes ────────────────────────────────────────────────────────────────────
 
+@app.route("/health")
+def health():
+    """Container health/readiness probe — always public."""
+    try:
+        _version = importlib.metadata.version("cashel")
+    except importlib.metadata.PackageNotFoundError:
+        _version = "dev"
+    entries = list_archive()
+    last_audit = entries[0]["timestamp"] if entries else None
+    return jsonify({
+        "ok":               True,
+        "version":          _version,
+        "uptime_seconds":   round(time.time() - _start_time),
+        "scheduler_running": scheduler_available(),
+        "last_audit_at":    last_audit,
+    })
+
+
+@app.route("/login", methods=["GET"])
+def login():
+    if session.get("authenticated"):
+        return redirect(url_for("index"))
+    return render_template("login.html")
+
+
+@app.route("/login", methods=["POST"])
+def login_post():
+    key = request.form.get("api_key", "")
+    settings = get_settings()
+    stored   = settings.get("api_key", "")
+    if stored and secrets.compare_digest(key, stored):
+        session.clear()
+        session["authenticated"] = True
+        session["last_seen"]     = time.time()
+        next_url = request.args.get("next", "")
+        # Guard against open-redirect: only accept relative paths
+        if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+            return redirect(next_url)
+        return redirect(url_for("index"))
+    return render_template("login.html", error="Invalid API key. Please try again."), 401
+
+
+@app.route("/logout", methods=["POST"])
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
+
+
 @app.route("/")
 def index():
     licensed, license_info = check_license()
@@ -359,6 +505,7 @@ def index():
 
 
 @app.route("/audit", methods=["POST"])
+@limiter.limit("30/minute")
 def run_audit():
     if "config" not in request.files or request.files["config"].filename == "":
         return jsonify({"error": "No config file uploaded"}), 400
@@ -379,6 +526,10 @@ def run_audit():
         return jsonify({"error": f"Unknown compliance framework '{compliance}'."}), 400
 
     upload = request.files["config"]
+    upload.seek(0, 2)
+    if upload.tell() > _MAX_FILE_BYTES:
+        return jsonify({"error": "File exceeds the 5 MB per-file limit."}), 413
+    upload.seek(0)
     suffix = Path(upload.filename).suffix or ".txt"
     temp_name = f"{uuid.uuid4()}{suffix}"
     temp_path = os.path.join(UPLOAD_FOLDER, temp_name)
@@ -473,6 +624,7 @@ def run_audit():
 # ── Config diff ───────────────────────────────────────────────────────────────
 
 @app.route("/diff", methods=["POST"])
+@limiter.limit("30/minute")
 def run_diff():
     if "config_a" not in request.files or "config_b" not in request.files:
         return jsonify({"error": "Two config files required (config_a and config_b)"}), 400
@@ -534,6 +686,7 @@ def run_diff():
 # ── Live SSH connect ──────────────────────────────────────────────────────────
 
 @app.route("/connect", methods=["POST"])
+@limiter.limit("10/minute")
 def live_connect():
     host       = request.form.get("host", "").strip()
     port       = request.form.get("port", "22").strip() or "22"
@@ -550,6 +703,19 @@ def live_connect():
     if vendor == "cisco":
         vendor = "asa"
 
+    # PEM key-based auth (optional)
+    pem_key_path   = None
+    pem_passphrase = request.form.get("pem_passphrase", "") or None
+    pem_upload     = request.files.get("pem_key")
+    if pem_upload and pem_upload.filename:
+        pem_path = os.path.join(UPLOAD_FOLDER, f"cashel_pem_{uuid.uuid4().hex}.pem")
+        pem_upload.save(pem_path)
+        try:
+            os.chmod(pem_path, 0o600)
+        except OSError:
+            pass
+        pem_key_path = pem_path
+
     label = f"{vendor.upper()}@{host}"
 
     try:
@@ -559,12 +725,16 @@ def live_connect():
             vendor, host, port, username, password,
             timeout=30, upload_folder=UPLOAD_FOLDER,
             host_key_policy=_settings.get("ssh_host_key_policy", "warn"),
+            pem_key_path=pem_key_path,
+            pem_passphrase=pem_passphrase,
         )
     except Exception as e:
-        # Log the failed attempt to activity log only — do NOT save to Audit History
         log_activity(ACTION_SSH_CONNECT, label, vendor=vendor, success=False, error=str(e),
                      details={"host": host, "port": port})
         return jsonify({"error": f"Connection failed: {e}"}), 500
+    finally:
+        if pem_key_path and os.path.exists(pem_key_path):
+            os.remove(pem_key_path)
 
     try:
         findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
@@ -729,6 +899,7 @@ def activity_clear():
 # ── Bulk audit ────────────────────────────────────────────────────────────────
 
 @app.route("/bulk_audit", methods=["POST"])
+@limiter.limit("10/minute")
 def bulk_audit():
     """Audit multiple config files in one request.
 
@@ -960,7 +1131,12 @@ def license_status():
 
 @app.route("/settings", methods=["GET"])
 def settings_get():
-    return jsonify(get_settings())
+    s = get_settings()
+    # Never expose the plaintext API key over the wire — return masked hint only
+    raw_key = s.pop("api_key", "")
+    s["api_key_set"] = bool(raw_key)
+    s["api_key_hint"] = ("csh_…" + raw_key[-4:]) if len(raw_key) >= 4 else ("set" if raw_key else "")
+    return jsonify(s)
 
 
 @app.route("/settings", methods=["POST"])
@@ -969,7 +1145,18 @@ def settings_save():
     saved = save_settings(data)
     # Reconfigure syslog immediately when settings are changed.
     configure_syslog(saved)
+    saved.pop("api_key", None)
     return jsonify(saved)
+
+
+@app.route("/settings/generate-api-key", methods=["POST"])
+def settings_generate_api_key():
+    """Generate a new random API key, store it encrypted, and return it once in plaintext.
+    The caller must copy and store the key immediately — it cannot be retrieved again.
+    """
+    new_key = "csh_" + secrets.token_urlsafe(32)
+    save_api_key(new_key)
+    return jsonify({"ok": True, "api_key": new_key})
 
 
 @app.route("/settings/test-smtp", methods=["POST"])
@@ -1023,6 +1210,168 @@ def settings_test_smtp():
         return jsonify({"ok": False, "message": f"SMTP error: {exc}"})
     except OSError as exc:
         return jsonify({"ok": False, "message": f"Connection error: {exc}"})
+
+
+# ── REST API v1 (CI/CD integration) ───────────────────────────────────────────
+# Blueprint registered above; CSRF exempt — authenticated via X-API-Key header.
+# All responses use the envelope: {"ok": bool, "data": ..., "error": str|null}
+
+def _api_ok(data):
+    return jsonify({"ok": True, "data": data, "error": None})
+
+
+def _api_err(message, status=400):
+    return jsonify({"ok": False, "data": None, "error": message}), status
+
+
+@api_bp.route("/audit", methods=["POST"])
+@limiter.limit("30/minute")
+def api_audit():
+    """POST /api/v1/audit — audit a config file, returns findings + summary."""
+    if "config" not in request.files or not request.files["config"].filename:
+        return _api_err("config file is required")
+
+    vendor     = request.form.get("vendor", "auto").strip().lower()
+    compliance = request.form.get("compliance", "").strip().lower() or None
+    archive_it = request.form.get("archive", "1") == "1"
+    tag        = request.form.get("tag", "").strip() or None
+
+    if vendor not in ("auto", *ALL_VENDORS):
+        return _api_err(f"Unknown vendor '{vendor}'.")
+
+    from .schedule_store import VALID_FRAMEWORKS
+    if compliance and compliance not in VALID_FRAMEWORKS:
+        return _api_err(f"Unknown compliance framework '{compliance}'.")
+
+    upload = request.files["config"]
+    upload.seek(0, 2)
+    if upload.tell() > _MAX_FILE_BYTES:
+        return _api_err("File exceeds the 5 MB per-file limit.", 413)
+    upload.seek(0)
+
+    suffix    = Path(upload.filename).suffix or ".txt"
+    temp_path = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix}")
+    upload.save(temp_path)
+
+    try:
+        sample = open(temp_path, encoding="utf-8", errors="ignore").read(4096)
+
+        if vendor in ("auto", "cisco"):
+            detected = detect_vendor(sample, upload.filename)
+            if vendor == "auto":
+                if not detected:
+                    return _api_err("Could not auto-detect vendor. Specify vendor explicitly.")
+                vendor = detected
+            elif vendor == "cisco":
+                vendor = "ftd" if is_ftd_config(sample) else "asa"
+        elif vendor == "asa" and is_ftd_config(sample):
+            vendor = "ftd"
+
+        findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
+
+        if compliance and vendor not in ("aws", "azure", "gcp", "iptables", "nftables"):
+            licensed, _ = check_license()
+            if licensed:
+                raw = run_compliance_checks(vendor, compliance, parse, extra_data)
+                findings += [_wrap_compliance(c) for c in raw]
+
+        findings = _sort_findings(findings)
+        summary  = _build_summary(findings)
+        archive_id = None
+        if archive_it:
+            archive_id, _ = save_audit(
+                upload.filename, vendor, _findings_to_strings(findings),
+                summary, config_path=temp_path, tag=tag,
+            )
+
+        return _api_ok({
+            "archive_id":        archive_id,
+            "vendor":            vendor,
+            "summary":           summary,
+            "findings":          _findings_to_strings(findings),
+            "enriched_findings": findings,
+            "detected_hostname": extract_hostname(vendor, sample),
+        })
+    except Exception as e:
+        return _api_err(_err(e, "Audit failed."), 500)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+@api_bp.route("/audit/<entry_id>", methods=["GET"])
+def api_audit_get(entry_id):
+    """GET /api/v1/audit/<id> — retrieve a specific archived audit result."""
+    entry = get_entry(entry_id)
+    if not entry:
+        return _api_err("Audit not found.", 404)
+    return _api_ok(entry)
+
+
+@api_bp.route("/history", methods=["GET"])
+def api_history():
+    """GET /api/v1/history — list audit history (metadata only, no findings)."""
+    try:
+        limit  = min(int(request.args.get("limit", 50)), 500)
+    except (ValueError, TypeError):
+        limit  = 50
+    vendor_filter = request.args.get("vendor", "").strip().lower() or None
+    tag_filter    = request.args.get("tag", "").strip() or None
+
+    entries = list_archive()
+    if vendor_filter:
+        entries = [e for e in entries if e.get("vendor") == vendor_filter]
+    if tag_filter:
+        entries = [e for e in entries if e.get("tag") == tag_filter]
+    entries = entries[:limit]
+
+    # Strip bulky findings list from history response
+    slim = [{k: v for k, v in e.items() if k != "findings"} for e in entries]
+    return _api_ok(slim)
+
+
+@api_bp.route("/diff", methods=["POST"])
+@limiter.limit("30/minute")
+def api_diff():
+    """POST /api/v1/diff — compare two config files."""
+    if "config_a" not in request.files or "config_b" not in request.files:
+        return _api_err("config_a and config_b files are required.")
+
+    vendor = request.form.get("vendor", "auto").strip().lower()
+    if vendor not in ("auto", *ALL_VENDORS):
+        return _api_err(f"Unknown vendor '{vendor}'.")
+
+    paths = []
+    try:
+        for field in ("config_a", "config_b"):
+            f = request.files[field]
+            suffix = Path(f.filename).suffix or ".txt"
+            p = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix}")
+            f.save(p)
+            paths.append(p)
+
+        path_a, path_b = paths
+        sample_a = open(path_a, encoding="utf-8", errors="ignore").read(4096)
+
+        if vendor in ("auto", "cisco"):
+            detected = detect_vendor(sample_a, request.files["config_a"].filename)
+            vendor   = detected if vendor == "auto" and detected else (
+                ("ftd" if is_ftd_config(sample_a) else "asa") if vendor == "cisco" else (detected or "asa")
+            )
+        elif vendor == "asa" and is_ftd_config(sample_a):
+            vendor = "ftd"
+
+        result = diff_configs(vendor, path_a, path_b)
+        return _api_ok(result)
+    except Exception as e:
+        return _api_err(_err(e, "Diff failed."), 500)
+    finally:
+        for p in paths:
+            if os.path.exists(p):
+                os.remove(p)
+
+
+app.register_blueprint(api_bp)
 
 
 def main():


### PR DESCRIPTION
## Summary

Implements roadmap items #1, #4, #5 and all security/infrastructure items:

**Public roadmap**
- **API key authentication (#1)** — Browser login page (`/login`), sliding-window session TTL, `X-API-Key` header support for CI/CD. Key stored Fernet-encrypted (`api_key_enc`), never re-exposed after generation. Auth settings pane in UI: enable/disable toggle, session lifetime, one-click key generation with clipboard copy.
- **PEM key SSH auth (#4)** — RSA / ECDSA / Ed25519 tried in sequence via paramiko; `pem_key_path` / `pem_passphrase` wired through all `_pull_*` helpers, `connect_and_pull()`, and the Live Connect UI (auth method radio: Password / PEM Key File).
- **REST API for CI/CD (#5)** — `/api/v1/` Blueprint with `POST /audit`, `GET /audit/<id>`, `GET /history`, `GET /diff`. Consistent `{"ok", "data", "error"}` envelope. CSRF-exempt; accepts `X-API-Key` header.

**Security/infrastructure**
- **CSP header with nonces** — Per-request `g.csp_nonce` (16-byte random); injected as `nonce=` on all `<script>` tags. Full `Content-Security-Policy` header via `after_request`.
- **Rate limiting** — `flask-limiter>=3.5` with `memory://` storage; 30 req/min on `/audit` + `/diff`, 10 req/min on `/connect` + `/bulk_audit`. 429 returns JSON.
- **Input size limits** — `MAX_CONTENT_LENGTH = 50 MB`; 5 MB per-file guard in `run_audit` (returns 413 JSON). `@app.errorhandler(413)` added.
- **Health endpoint** — `GET /health` always public; returns `version`, `uptime_seconds`, `scheduler_running`, `last_audit_at`.
- **Hardened cookies** — `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SAMESITE=Lax`, `SESSION_COOKIE_SECURE` via `CASHEL_SECURE_COOKIES` env var.
- **X-Frame-Options: DENY** added to security headers.

**Bug fix**
- `juniper.py`: mypy `arg-type` error on `content_or_err: str | None` — narrowed with `or ""` assignment.

## Test plan

- [ ] `python3 -m ruff check src/` — all checks passed ✓
- [ ] `python3 -m mypy src/cashel/ --ignore-missing-imports` — no issues ✓
- [ ] `python3 -m pytest tests/ -q` — 157 passed ✓
- [ ] `pyproject.toml` deps match `requirements.txt` ✓
- [ ] Manual: enable auth in settings, generate key, log out, log back in with key
- [ ] Manual: `curl -H "X-API-Key: csh_..." /api/v1/audit` returns `{"ok":true,...}`
- [ ] Manual: `/health` returns JSON without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)