### PR TITLE
Fix: crypto key path, API key masking, CI workflow, docs housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]" 2>/dev/null || pip install -e . && pip install ruff mypy pytest
+
+      - name: Ruff lint
+        run: ruff check src/ tests/
+
+      - name: Ruff format check
+        run: ruff format --check src/ tests/
+
+      - name: mypy type check
+        run: mypy src/cashel/ --ignore-missing-imports
+
+      - name: XML safety check
+        run: |
+          if grep -r "xml.etree" src/cashel/ --include="*.py"; then
+            echo "ERROR: Use defusedxml instead of xml.etree"
+            exit 1
+          fi
+
+      - name: Dependency sync check
+        run: |
+          python -c "
+          import re
+          reqs = open('requirements.txt').read()
+          toml = open('pyproject.toml').read()
+          deps = re.findall(r'^([a-zA-Z0-9_-]+)', reqs, re.MULTILINE)
+          missing = [d for d in deps if d.lower() not in toml.lower()]
+          if missing:
+              print('Missing from pyproject.toml:', missing)
+              exit(1)
+          "
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+**CLAUDE.md**
+
+# Cashel — Claude Code Guide
+
+Cashel is a firewall configuration auditing tool with a CLI and Flask web UI. It parses configs from 11 firewall vendors, scores them, and checks compliance against frameworks like SOC2, DISA STIG, PCI-DSS, HIPAA, CIS, and NIST SP 800-41.
+
+## Project Structure
+
+```
+src/cashel/             # Main package
+  main.py               # CLI entry point (typer)
+  web.py                # Flask web UI
+  audit_engine.py       # Core scoring and findings logic (includes ASA audit helpers)
+  compliance.py         # All compliance framework checks (paid feature)
+  reporter.py           # PDF report generation (fpdf2)
+  export.py             # JSON / CSV / SARIF export
+  diff.py               # Config diff / comparison
+  rule_quality.py       # Shadow and duplicate rule detection
+  notify.py             # Slack / Teams / Email alerts
+  syslog_handler.py     # Syslog forwarding
+  ssh_connector.py      # Paramiko SSH connections
+  scheduler_runner.py   # APScheduler recurring audits
+  schedule_store.py     # Persists scheduled audit config
+  activity_log.py       # Audit history
+  archive.py            # Historical audit storage
+  settings.py           # User settings management
+  license.py            # License key validation (compliance gate)
+  # Vendor parsers — Cisco is the vendor; ASA and FTD are different appliances:
+  audit_engine.py       # Also contains _audit_asa() for Cisco ASA appliances
+  ftd.py                # Cisco FTD (Firepower Threat Defense) appliances
+  iptables.py           # iptables-save and nftables
+  juniper.py            # Juniper SRX (set-style and hierarchical)
+  paloalto.py           # Palo Alto (XML)
+  fortinet.py           # Fortinet FortiGate
+  pfsense.py            # pfSense (XML)
+  aws.py                # AWS Security Groups (JSON)
+  azure.py              # Azure NSG (JSON)
+  gcp.py                # GCP VPC Firewall (JSON)
+tests/                  # Test suite — run as plain Python scripts
+```
+
+## Running Tests
+
+Tests use the standard library `unittest` and are run directly (no pytest required):
+
+```bash
+# Run a single test file
+python3 tests/test_iptables.py
+python3 tests/test_juniper.py
+python3 tests/test_gcp.py
+python3 tests/test_export.py
+python3 tests/test_notify.py
+python3 tests/test_rule_quality.py
+python3 tests/test_soc2_stig.py
+
+# Run all tests at once (if pytest is installed)
+python -m pytest tests/ -v
+```
+
+Each test file inserts `src/` into `sys.path` at the top — no install required.
+
+## Test Fixtures
+
+Vendor config fixtures live in `tests/`:
+- `test_asa.txt` — Cisco ASA ACL config
+- `test_forti.txt` — Fortinet FortiGate policy config
+- `test_pa.xml` — Palo Alto XML config
+- `test_pfsense.xml` — pfSense XML config
+
+## Vendor Naming Convention
+
+**Cisco** is the vendor. The ASA (Adaptive Security Appliance) and FTD (Firepower Threat Defense) are
+different Cisco appliances, but they share LINA CLI syntax. In the vendor dispatch code they use the
+`"asa"` and `"ftd"` vendor keys respectively. Tests for both live in `tests/test_cisco.py`.
+
+## Test Coverage Gaps
+
+All primary vendor modules now have test files. Remaining gap:
+
+| Module | Status |
+|---|---|
+| `compliance.py` | Partially covered — `test_soc2_stig.py` covers SOC2/STIG; CIS/NIST/PCI/HIPAA checks need expansion |
+
+## Roadmap Status
+
+### Done
+- [x] API key authentication with session management
+- [x] Fernet encryption for stored credentials
+- [x] CSRF protection (Flask-WTF)
+- [x] Multi-factor SSH authentication (PEM key support)
+- [x] REST API for CI/CD pipeline integration
+- [x] Rate limiting (Flask-Limiter)
+- [x] Content Security Policy (CSP) header with nonce
+- [x] Input size limits (50MB total, 5MB per file)
+- [x] Health endpoint (GET /health)
+
+### Pending
+- [ ] Local username/password auth (see Auth Expansion Plan in PLAN.md)
+- [ ] LDAP / Active Directory auth
+- [ ] OIDC auth (Okta, Azure AD, Google)
+- [ ] TACACS+ auth
+- [ ] web.py decomposition into blueprints
+- [ ] GitHub Actions CI pipeline
+- [ ] Docker image hardening (non-root user, pinned digest)
+- [ ] Structured logging (replace print() with logging module)
+
+## Architecture Notes
+
+- **Compliance features are gated** by a license key checked in `license.py`. The `keygen.py` utility (gitignored) generates keys via SHA256 hash.
+- **Vendor parsers** follow a consistent pattern: `parse_<vendor>()` → returns a list of rule dicts, then `audit_<vendor>()` → calls individual `check_*()` functions and returns findings.
+- **Findings** are dicts with keys: `id`, `title`, `severity` (`critical`/`high`/`medium`/`low`/`info`), `description`, `remediation`, `category`.
+- **`audit_engine.py`** computes the 0–100 security score from findings and is vendor-agnostic.
+- **`web.py`** is large (~1,600 lines). Flask routes handle file upload, SSH, scheduling, diff, export, and settings.
+- **XML parsing** always uses `defusedxml` (never `xml.etree`) for XXE protection.
+
+## Code Style
+
+- Python 3.8+ compatible
+- Linting: `ruff` (see commit history for fixes)
+- No type annotations required, but keep existing ones consistent
+- Avoid `xml.etree` — always use `defusedxml.ElementTree`
+
+## Installation (Development)
+
+```bash
+pip install -e .
+# or
+pip install -r requirements.txt
+```
+
+Both `requirements.txt` and `pyproject.toml` are the source of truth for dependencies and should be kept in sync. The pre-merge validation Stop hook checks for drift between them.
+```
+
+---
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,7 +35,7 @@ These are **not** public roadmap items and should not appear in README.md.
 
 ### Code Quality
 - [ ] **main.py refactor** — summary block duplicated 4× (one per vendor); doesn't use `audit_engine.run_vendor_audit`; vendors added to `audit_engine` but not wired in CLI
-- [ ] **web.py decomposition** — ~1,600 lines; split into blueprints (audit, ssh, schedule, history, settings, export)
+- [ ] **web.py decomposition** — now ~2,000 lines; must be completed **before** the auth expansion (Phase 1) to avoid making the file unmanageable. See detailed plan below.
 - [ ] **mypy strictness** — currently `--no-strict-optional`; tighten incrementally as annotations are added
 - [ ] **Python 3.8 compat** — `pyproject.toml` says `>=3.8` but code uses `list[dict]` annotations (3.9+); either drop 3.8 support or use `from __future__ import annotations`
 
@@ -102,3 +102,66 @@ Full multi-provider authentication to replace the current single API-key model.
 - New blueprint: `src/cashel/blueprints/auth.py` (all /auth/* routes)
 - Session handling unchanged — all providers issue the same Flask session cookie
 - Provider switching: warn user that sessions will be invalidated
+
+---
+
+## web.py Decomposition Plan
+
+**Must be completed before auth expansion Phase 1.** The auth work adds a new blueprint, new middleware, and new settings routes. Doing that against a 2,000-line `web.py` creates unacceptable merge complexity and makes the file nearly unmaintainable.
+
+### Target structure
+
+```
+src/cashel/
+  web.py                   # App factory only: config, limiter, middleware wiring,
+                           # blueprint registration, main() entry point (~150 lines)
+  _vendor_helpers.py       # detect_vendor(), validate_vendor_format(),
+                           # extract_hostname() — pure functions, no Flask dep
+  blueprints/
+    __init__.py
+    auth.py                # /login, /logout  (+ future LDAP/OIDC/TACACS routes)
+    audit.py               # /audit, /bulk_audit, /diff, /connect
+    history.py             # /archive/*, /activity/*
+    schedules.py           # /schedules/*
+    settings.py            # /settings/*, /license/*
+    reports.py             # /reports/*
+    api_v1.py              # /api/v1/* (existing api_bp, unchanged externally)
+```
+
+### Route → blueprint mapping
+
+| Current route(s) | Blueprint | Notes |
+|---|---|---|
+| `/login` GET/POST, `/logout` | `auth.py` | Seed location for LDAP/OIDC callbacks |
+| `/audit`, `/bulk_audit`, `/diff`, `/connect` | `audit.py` | Takes `_vendor_helpers` as import |
+| `/archive/*`, `/activity/*` | `history.py` | |
+| `/schedules/*` | `schedules.py` | |
+| `/settings`, `/settings/*`, `/license/*` | `settings.py` | |
+| `/reports/*` | `reports.py` | |
+| `/api/v1/*` | `api_v1.py` | Rename from inline `api_bp`; CSRF-exempt flag stays |
+| `/`, `/health` | `web.py` (keep inline) | Too small to warrant a blueprint |
+
+### Shared state strategy
+
+All blueprints need access to `limiter`, `csrf`, and `get_settings()`. Approach:
+- `limiter` and `csrf` are imported from `web.py` by each blueprint (`from cashel.web import limiter`)
+- `get_settings()` is already a standalone import from `settings.py` — no change needed
+- `_require_auth` stays in `web.py` as an `app.before_request` so it fires globally across all blueprints without each blueprint needing to re-register it
+- `_err()` helper moves to a shared `_helpers.py` module imported by any blueprint that needs it
+
+### Migration order (lowest risk first)
+
+1. **Extract `_vendor_helpers.py`** — pure functions, zero Flask dep; easiest to test in isolation
+2. **`reports.py`** — read-only routes, no auth complexity, good warm-up
+3. **`history.py`** — archive + activity; touches archive.py and activity_log.py
+4. **`schedules.py`** — touches schedule_store.py and scheduler_runner.py
+5. **`settings.py`** — touches settings.py, crypto.py, license.py
+6. **`api_v1.py`** — already a Blueprint internally; mostly a file move + import update
+7. **`audit.py`** — largest chunk; depends on `_vendor_helpers` being extracted first
+8. **`auth.py`** — last, because it also becomes the home for Phase 1 local auth routes
+
+### Acceptance criteria
+- All existing routes respond identically (same URL, same response shape)
+- `web.py` drops below 200 lines
+- `pytest tests/ -v` passes with no changes to test files
+- `ruff` and `mypy` clean throughout

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+**PLAN.md**
+
+
+# Cashel — Project Plan
+
+Internal working document. Not the public roadmap (see README.md).
+
+---
+
+## Active: README Roadmap Items
+
+These map 1-to-1 with the `[ ]` items in README.md and will be checked off there when done.
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| 1 | API key authentication with session management | **Done** | Web UI login + API key for CLI/programmatic access |
+| 2 | Fernet encryption for stored credentials | **Done** | schedule_store.py + settings.py; crypto.py module; base64 migration fallback |
+| 3 | CSRF protection (Flask-WTF) | **Done** | CSRFProtect on all routes; JS fetch interceptor adds X-CSRFToken header |
+| 4 | Multi-factor SSH authentication (key-based) | **Done** | PEM/passphrase support in ssh_connector.py |
+| 5 | REST API for CI/CD pipeline integration | **Done** | JSON API wrapping existing audit_engine |
+
+---
+
+## Engineering / Internal Work
+
+These are **not** public roadmap items and should not appear in README.md.
+
+### Testing & CI
+- [ ] **Scheduled CI (GitHub Actions)** — on PR: ruff + mypy + pytest; on merge/main: full suite + secret scan; nightly: pip-audit
+- [ ] **pip-audit nightly job** — automate dependency CVE scanning; alert on new critical/high vulns
+- [ ] **Integration tests** — Docker Compose test environment with mock SSH server (paramiko stub or sshesame); test full audit flow end-to-end
+- [ ] **APScheduler tests** — use `freezegun` to test scheduled job firing, cron intervals, and missed-run behavior without wall-clock waiting
+- [ ] **Compliance test expansion** — `test_soc2_stig.py` only covers SOC2/STIG; need CIS, NIST, PCI-DSS, HIPAA checks in `compliance.py`
+- [ ] **Address pytest warnings** — 3 test functions in `test_rule_quality.py` return values instead of asserting (PytestReturnNotNoneWarning)
+
+### Code Quality
+- [ ] **main.py refactor** — summary block duplicated 4× (one per vendor); doesn't use `audit_engine.run_vendor_audit`; vendors added to `audit_engine` but not wired in CLI
+- [ ] **web.py decomposition** — ~1,600 lines; split into blueprints (audit, ssh, schedule, history, settings, export)
+- [ ] **mypy strictness** — currently `--no-strict-optional`; tighten incrementally as annotations are added
+- [ ] **Python 3.8 compat** — `pyproject.toml` says `>=3.8` but code uses `list[dict]` annotations (3.9+); either drop 3.8 support or use `from __future__ import annotations`
+
+### Security
+- [x] **Rate limiting** — Flask-Limiter, memory:// storage, 30/min on audit/diff, 10/min on connect
+- [x] **Content Security Policy (CSP) header** — nonce-based, injected via g.csp_nonce before_request
+- [x] **Input size limits** — MAX_CONTENT_LENGTH=50MB, per-file 5MB check in routes
+- [ ] **SSRF review** — webhook allowlist covers Slack/Teams/Discord; verify no other outbound HTTP calls are user-influenced
+
+### Infrastructure
+- [ ] **Docker image hardening** — run as non-root user in Dockerfile; pin base image digest
+- [x] **Health endpoint** — GET /health — version, uptime, scheduler status, public
+- [ ] **Structured logging** — replace `print()` calls in vendor parsers with Python `logging` module; enables log-level control and SIEM routing
+
+---
+
+## Decisions Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-03-22 | All new features developed in `claude/` branches before merge to main | Keeps main stable; reviewed before merge |
+| 2026-03-22 | Test files run as plain Python scripts (no pytest dependency at runtime) | Zero extra deps for contributors; pytest still works for CI |
+| 2026-03-22 | defusedxml required everywhere XML is parsed | XXE protection; enforced by xml.etree safety check in Stop hook |
+| 2026-03-22 | Pre-merge validation runs 6 checks: ruff, mypy, xml-safety, dep-sync, CLI contracts, pytest | Catches linting, type, security, and functional regressions before push |
+| 2026-03-24 | Project renamed from Flintlock to Cashel | Rebranding; package path changed from src/flintlock/ to src/cashel/ |
+| 2026-03-24 | Default Fernet key path changed from /data/cashel.key to ~/.config/cashel/cashel.key | /data requires root on macOS; Docker/prod should set CASHEL_KEY_FILE explicitly |
+| 2026-03-24 | Auth expansion planned in 4 phases: local → LDAP → OIDC → TACACS+ | Ordered by implementation complexity and enterprise adoption frequency |
+
+---
+
+## Auth Expansion Plan
+
+Full multi-provider authentication to replace the current single API-key model.
+
+### Phase 1 — Local username/password (next up)
+- Store users in `~/.config/cashel/users.json` (bcrypt-hashed passwords)
+- Add `POST /auth/users` (create), `DELETE /auth/users/<username>`, `GET /auth/users` (list)
+- Login form gains a username field alongside password
+- Roles: `admin` (full access) and `viewer` (read-only: audit, history, diff, export)
+- Migrate: existing API-key sessions remain valid alongside new local auth
+
+### Phase 2 — LDAP/Active Directory
+- New dependency: `flask-ldap3-login` or raw `ldap3`
+- Settings pane: LDAP server, base DN, bind DN/password, group-to-role mapping
+- Bind→search→bind flow; TLS/STARTTLS required
+- Group mapping: configure AD groups → Cashel admin/viewer roles
+
+### Phase 3 — OIDC (Okta, Azure AD, Google Workspace)
+- New dependency: `authlib` (OAuth2/OIDC client)
+- Settings: OIDC discovery URL, client_id, client_secret, role claim
+- Callback route: `GET /auth/oidc/callback`
+- Token stored in session; refresh handled transparently
+- Supports Okta, Azure AD, Google Workspace, Keycloak out of the box
+
+### Phase 4 — TACACS+
+- New dependency: `tacacs-plus` (or socket-level implementation)
+- Settings: TACACS+ server host/port, shared secret, service/protocol
+- Auth-only flow (no accounting required for MVP)
+- Fallback: if TACACS+ unreachable, fall through to local auth
+
+### Implementation Notes
+- Auth provider selection stored in settings: `auth_provider: "local" | "ldap" | "oidc" | "tacacs"`
+- API key auth (X-API-Key header) always works in parallel for CI/CD regardless of provider
+- New blueprint: `src/cashel/blueprints/auth.py` (all /auth/* routes)
+- Session handling unchanged — all providers issue the same Flask session cookie
+- Provider switching: warn user that sessions will be invalidated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "defusedxml>=0.7",
 ]
 
+[project.optional-dependencies]
+dev = ["ruff", "mypy", "pytest"]
+
 [tool.poetry]
 packages = [{include = "cashel", from = "src"}]
 

--- a/src/cashel/crypto.py
+++ b/src/cashel/crypto.py
@@ -1,9 +1,13 @@
 """Fernet symmetric encryption for stored credentials.
 
-The key is generated on first use and persisted at CASHEL_KEY_FILE
-(default: /data/cashel.key). Treat this file like a private key —
-restrict permissions and back it up. Loss of this file means stored
-credentials cannot be recovered.
+The key is generated on first use and persisted at CASHEL_KEY_FILE.
+The default path is ``~/.config/cashel/cashel.key`` so the tool works
+out of the box on macOS and Linux without root access.  Docker and
+production deployments should override this by setting the environment
+variable ``CASHEL_KEY_FILE=/data/cashel.key`` explicitly.
+
+Treat this file like a private key — restrict permissions and back it
+up.  Loss of this file means stored credentials cannot be recovered.
 
 Migration: decrypt() silently falls back to legacy base64 decoding so
 existing schedule files and settings are transparently upgraded on next
@@ -15,7 +19,14 @@ import os
 from cryptography.fernet import Fernet, InvalidToken
 
 def _key_file() -> str:
-    return os.environ.get("CASHEL_KEY_FILE", "/data/cashel.key")
+    """Return the path to the Fernet key file.
+
+    Defaults to ``~/.config/cashel/cashel.key`` so local development
+    works without root access.  Set the ``CASHEL_KEY_FILE`` environment
+    variable to override (e.g. ``/data/cashel.key`` in Docker/prod).
+    """
+    default = os.path.join(os.path.expanduser("~"), ".config", "cashel", "cashel.key")
+    return os.environ.get("CASHEL_KEY_FILE", default)
 
 
 def _load_or_create_key() -> bytes:

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -847,7 +847,9 @@
                   <button class="btn-secondary" id="btnDismissKey" style="padding:0.2rem 0.6rem;font-size:0.78rem">Dismiss</button>
                 </div>
                 <div style="display:flex;align-items:center;gap:0.5rem">
-                  <code id="authNewKeyVal" style="flex:1;padding:0.5rem;background:var(--input-bg);border-radius:4px;word-break:break-all;font-size:0.88rem"></code>
+                  <input type="password" id="authNewKeyVal" readonly
+                         style="flex:1;padding:0.5rem;background:var(--input-bg);border:1px solid var(--border);border-radius:4px;word-break:break-all;font-size:0.88rem;color:var(--text);font-family:monospace" />
+                  <button class="btn-secondary" id="btnRevealKey">Show</button>
                   <button class="btn-secondary" id="btnCopyKey">Copy</button>
                 </div>
               </div>
@@ -2386,14 +2388,27 @@
   function _maskApiKeyBox() {
     clearInterval(_keyCountdownTimer);
     document.getElementById("authNewKeyBox").classList.add("hidden");
-    document.getElementById("authNewKeyVal").textContent = "";
+    document.getElementById("authNewKeyVal").value = "";
     document.getElementById("authKeyCountdown").textContent = "60";
+    const revealBtn = document.getElementById("btnRevealKey");
+    if (revealBtn) { revealBtn.textContent = "Show"; document.getElementById("authNewKeyVal").type = "password"; }
   }
 
   document.getElementById("btnDismissKey").addEventListener("click", _maskApiKeyBox);
 
+  document.getElementById("btnRevealKey").addEventListener("click", function () {
+    const inp = document.getElementById("authNewKeyVal");
+    if (inp.type === "password") {
+      inp.type = "text";
+      this.textContent = "Hide";
+    } else {
+      inp.type = "password";
+      this.textContent = "Show";
+    }
+  });
+
   document.getElementById("btnCopyKey").addEventListener("click", function () {
-    const val = document.getElementById("authNewKeyVal").textContent;
+    const val = document.getElementById("authNewKeyVal").value;
     navigator.clipboard.writeText(val)
       .then(() => { this.textContent = "Copied!"; setTimeout(() => { this.textContent = "Copy"; }, 1500); })
       .catch(() => { this.textContent = "Error"; });
@@ -2409,7 +2424,7 @@
         alert("Failed to generate key: " + (data.error || "Unknown error"));
         return;
       }
-      document.getElementById("authNewKeyVal").textContent = data.api_key;
+      document.getElementById("authNewKeyVal").value = data.api_key;
       document.getElementById("authNewKeyBox").classList.remove("hidden");
       document.getElementById("authKeyHint").textContent   = data.api_key_hint || (data.api_key.slice(0, 8) + "…");
 


### PR DESCRIPTION
## Summary

- **Crypto key path fix**: Change default Fernet key path from `/data/cashel.key` to `~/.config/cashel/cashel.key` so local development works without root access. Docker/prod deployments set `CASHEL_KEY_FILE` explicitly.
- **API key masking UI**: Replace the plaintext `<code>` element for generated API keys with a `password`-type input and a Show/Hide toggle button so the key is masked by default.
- **PLAN.md / CLAUDE.md updates**: Mark recently shipped features (API key auth, PEM SSH, REST API, rate limiting, CSP, input limits, health endpoint) as done; add Auth Expansion Plan (4 phases: local → LDAP → OIDC → TACACS+); update Decisions Log.
- **GitHub Actions CI**: Add `.github/workflows/ci.yml` with ruff lint/format, mypy, XML safety check, dependency sync check, and pytest. Add `dev` extras to `pyproject.toml`.

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `mypy src/cashel/ --ignore-missing-imports` — no issues in 28 source files
- [x] `pytest tests/ -v` — 157 passed, 0 failures
- [ ] Manually verify: generate an API key in the Settings → Auth pane, confirm it shows as masked by default, Show/Hide toggle works, Copy reads the correct value
- [ ] Verify: fresh local run without `CASHEL_KEY_FILE` set creates key at `~/.config/cashel/cashel.key`
- [ ] Verify: CI workflow triggers on next PR to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)