### PR TITLE
Fix: CSP nonce bug, button layout, upload fallback, demo SMTP/syslog

### DIFF
--- a/src/cashel/static/style.css
+++ b/src/cashel/static/style.css
@@ -576,6 +576,7 @@ select:focus, input[type="text"]:focus {
 /* Actions row — holds PDF, export, and archive divs on one line */
 .actions-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 .actions-row > .pdf-row,
+.actions-row > .remediation-row,
 .actions-row > .export-row,
 .actions-row > .archive-row { display: flex; align-items: center; gap: 0.5rem; margin-top: 0; }
 
@@ -1562,7 +1563,7 @@ select:focus, input[type="text"]:focus {
   font-weight: 600;
 }
 .remediation-row {
-  margin-top: 0.5rem;
+  margin-top: 0.5rem; /* overridden to 0 when inside .actions-row */
 }
 .remediation-modal-box {
   max-width: 780px;

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -218,7 +218,7 @@
         <div id="findingsPagination" class="findings-pagination hidden"></div>
         <div class="actions-row">
           <div class="pdf-row hidden" id="pdfRow">
-            <a id="pdfLink" class="btn-download" href="#" download>&#8681; Download PDF</a>
+            <a id="pdfLink" class="btn-secondary" href="#" download>&#8681; Download PDF</a>
             <a id="pdfViewLink" class="btn-secondary" href="#" target="_blank" rel="noopener">&#128196; View PDF</a>
           </div>
           <div class="remediation-row hidden" id="remediationRow">
@@ -2794,7 +2794,7 @@
     </div>
   </div>
 
-  <script nonce="{{ csp_nonce }}">
+  <script nonce="{{ g.csp_nonce }}">
   (function() {
     const modal = document.getElementById("remediationModal");
     const body  = document.getElementById("remediationModalBody");

--- a/src/cashel/web.py
+++ b/src/cashel/web.py
@@ -79,7 +79,27 @@ ARCHIVE_FOLDER = os.environ.get("ARCHIVE_FOLDER", "/tmp/cashel_archive")
 ACTIVITY_FOLDER = os.environ.get("ACTIVITY_FOLDER", "/tmp/cashel_activity")
 
 for _d in (UPLOAD_FOLDER, REPORTS_FOLDER, ARCHIVE_FOLDER, ACTIVITY_FOLDER):
-    os.makedirs(_d, exist_ok=True)
+    try:
+        os.makedirs(_d, exist_ok=True)
+    except OSError:
+        pass  # Writability is checked at use-time via _make_temp_path
+
+
+def _make_temp_path(suffix: str) -> str:
+    """Return a writable temp path, preferring UPLOAD_FOLDER with system-temp fallback."""
+    import tempfile
+
+    candidate = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix}")
+    try:
+        fd = os.open(candidate, os.O_CREAT | os.O_WRONLY, 0o600)
+        os.close(fd)
+        os.unlink(candidate)
+        return candidate
+    except OSError:
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        os.close(fd)
+        return path
+
 
 # Settings folder is created lazily by settings.py on first save
 
@@ -1053,8 +1073,7 @@ def run_audit():
         return jsonify({"error": "File exceeds the 5 MB per-file limit."}), 413
     upload.seek(0)
     suffix = Path(upload.filename).suffix or ".txt"
-    temp_name = f"{uuid.uuid4()}{suffix}"
-    temp_path = os.path.join(UPLOAD_FOLDER, temp_name)
+    temp_path = _make_temp_path(suffix)
     upload.save(temp_path)
 
     try:
@@ -1209,8 +1228,8 @@ def run_diff():
     upload_b = request.files["config_b"]
     suffix_a = Path(upload_a.filename).suffix or ".txt"
     suffix_b = Path(upload_b.filename).suffix or ".txt"
-    path_a = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix_a}")
-    path_b = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix_b}")
+    path_a = _make_temp_path(suffix_a)
+    path_b = _make_temp_path(suffix_b)
     upload_a.save(path_a)
     upload_b.save(path_b)
 
@@ -1299,7 +1318,7 @@ def live_connect():
     pem_passphrase = request.form.get("pem_passphrase", "") or None
     pem_upload = request.files.get("pem_key")
     if pem_upload and pem_upload.filename:
-        pem_path = os.path.join(UPLOAD_FOLDER, f"cashel_pem_{uuid.uuid4().hex}.pem")
+        pem_path = _make_temp_path(".pem")
         pem_upload.save(pem_path)
         try:
             os.chmod(pem_path, 0o600)
@@ -1682,8 +1701,7 @@ def bulk_audit():
             continue
 
         suffix = Path(upload.filename).suffix or ".txt"
-        temp_name = f"{uuid.uuid4()}{suffix}"
-        temp_path = os.path.join(UPLOAD_FOLDER, temp_name)
+        temp_path = _make_temp_path(suffix)
         upload.save(temp_path)
 
         result_entry = {
@@ -1980,6 +1998,8 @@ def settings_test_smtp():
     Accepts the same SMTP fields as /settings POST so the user can test
     before saving.  Returns {ok: bool, message: str}.
     """
+    if DEMO_MODE:
+        return jsonify({"ok": False, "message": "SMTP is disabled in demo mode."}), 403
     import smtplib
     import ssl
     from email.mime.text import MIMEText
@@ -2084,7 +2104,7 @@ def api_audit():
     upload.seek(0)
 
     suffix = Path(upload.filename).suffix or ".txt"
-    temp_path = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix}")
+    temp_path = _make_temp_path(suffix)
     upload.save(temp_path)
 
     try:
@@ -2214,7 +2234,7 @@ def api_diff():
         for field in ("config_a", "config_b"):
             f = request.files[field]
             suffix = Path(f.filename).suffix or ".txt"
-            p = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}{suffix}")
+            p = _make_temp_path(suffix)
             f.save(p)
             paths.append(p)
 
@@ -2255,7 +2275,8 @@ app.register_blueprint(api_bp)
 if os.environ.get("CASHEL_SKIP_SCHEDULER") != "1":
     start_scheduler()
     atexit.register(stop_scheduler)
-configure_syslog(get_settings())
+if not DEMO_MODE:
+    configure_syslog(get_settings())
 
 
 def main():


### PR DESCRIPTION
## Summary

- **Fix CSP nonce bug** — `{{ csp_nonce }}` → `{{ g.csp_nonce }}` in the remediation modal script tag. The undefined variable rendered as an empty string, causing the browser to silently block the entire script via CSP. This is why "View Remediation Plan" did nothing.
- **Button layout consistency** — Added `.remediation-row` to the `.actions-row >` flex selector so it participates in the row layout. Changed `btn-download` → `btn-secondary` on the "Download PDF" link to match the other buttons.
- **Robust upload path fallback** — `_make_temp_path()` helper probes `UPLOAD_FOLDER` writability and falls back to `tempfile.mkstemp` if the directory isn't writable. Applied to all 6 upload write sites. Fixes `PermissionError` when `UPLOAD_FOLDER=/data/uploads` is inherited outside Docker.
- **Block SMTP test in demo mode** — `/settings/test-smtp` now returns 403 in demo mode.
- **Block syslog on demo startup** — `configure_syslog()` gated by `if not DEMO_MODE`.

## Test plan

- [ ] Complete a file audit on staging → "View Remediation Plan" opens a populated modal
- [ ] Verify "Download PDF", "View Remediation Plan", and other action buttons look visually consistent
- [ ] Run with `UPLOAD_FOLDER=/data/uploads` outside Docker → audit completes without PermissionError
- [ ] Run with `CASHEL_DEMO_MODE=true` → "Test SMTP" returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)