### PR TITLE
Chore: remove demo-file entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,5 @@ CNAME
 # Internal planning and ops docs — never publish
 CLAUDE.md
 PLAN.md
-DEMO_SETUP.md
-
-# Demo files — live in private cashel-demo repo only
-.github/workflows/demo-deploy.yml
-.github/workflows/ensure-demo-files.yml
 vercel.json
 api/
-Dockerfile.demo
-src/cashel/demo_samples/


### PR DESCRIPTION
## Summary

- Removes `.gitignore` entries for demo-specific files (`Dockerfile.demo`, `DEMO_SETUP.md`, `demo-deploy.yml`, `ensure-demo-files.yml`, `src/cashel/demo_samples/`)
- These entries are no longer needed — with the two-folder structure (`cashel/` for prod, `cashel-demo/` for demo), demo files will never exist in this repo
- Keeps `vercel.json` and `api/` ignore entries (unrelated to demo files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)