### PR TITLE
Merge staging: remove demo-file .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,5 @@ CNAME
 # Internal planning and ops docs — never publish
 CLAUDE.md
 PLAN.md
-DEMO_SETUP.md
-
-# Demo files — live in private cashel-demo repo only
-.github/workflows/demo-deploy.yml
-.github/workflows/ensure-demo-files.yml
 vercel.json
 api/
-Dockerfile.demo
-src/cashel/demo_samples/


### PR DESCRIPTION
## Summary

- Removes `.gitignore` entries for demo-specific files that no longer belong in this repo
- Part of the two-folder structure migration (cashel/ for prod, cashel-demo/ for demo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)