### PR TITLE
CI: auto-sync cashel-demo after validate passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,21 @@ jobs:
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sync-demo:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Sync cashel-demo with upstream/main
+        env:
+          DEMO_REPO_TOKEN: ${{ secrets.DEMO_REPO_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git clone https://x-access-token:${DEMO_REPO_TOKEN}@github.com/Shamrock13/cashel-demo.git demo
+          cd demo
+          git remote add upstream https://github.com/Shamrock13/cashel.git
+          git fetch upstream
+          git merge upstream/main --no-edit
+          git push origin main


### PR DESCRIPTION
## Summary

Validated on staging. Merging to production.

- Adds `sync-demo` job to `ci.yml` gated on `validate` passing
- Skips on PRs and on validation failure — demo only syncs on clean main pushes
- Eliminates manual `upstream/main` sync step going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)