### PR TITLE
Fix: move sync-demo to separate workflow, avoid ci.yml conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,21 +63,3 @@ jobs:
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  sync-demo:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Sync cashel-demo with upstream/main
-        env:
-          DEMO_REPO_TOKEN: ${{ secrets.DEMO_REPO_TOKEN }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git clone https://x-access-token:${DEMO_REPO_TOKEN}@github.com/Shamrock13/cashel-demo.git demo
-          cd demo
-          git remote add upstream https://github.com/Shamrock13/cashel.git
-          git fetch upstream
-          git merge upstream/main --no-edit
-          git push origin main

--- a/.github/workflows/sync-demo.yml
+++ b/.github/workflows/sync-demo.yml
@@ -1,0 +1,25 @@
+name: Sync Demo
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  sync-demo:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Sync cashel-demo with upstream/main
+        env:
+          DEMO_REPO_TOKEN: ${{ secrets.DEMO_REPO_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git clone https://x-access-token:${DEMO_REPO_TOKEN}@github.com/Shamrock13/cashel-demo.git demo
+          cd demo
+          git remote add upstream https://github.com/Shamrock13/cashel.git
+          git fetch upstream
+          git merge upstream/main --no-edit -X theirs
+          git push origin main


### PR DESCRIPTION
## Summary

- Removes `sync-demo` job from `ci.yml` — both repos now share identical CI files, eliminating the merge conflict
- Creates `.github/workflows/sync-demo.yml` using `workflow_run` trigger — fires after CI completes successfully on main
- Adds `-X theirs` to the merge to auto-resolve any future conflicts in favour of cashel (upstream)

## Why this works

`ci.yml` is now identical between cashel and cashel-demo. When cashel-demo syncs from upstream, there's no conflict. `sync-demo.yml` propagates to cashel-demo but is harmless — when it runs there, `upstream/main` is already in sync so `git push` is a no-op and no loop occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)