### PR TITLE
fix: auth bug fixes from staging validation

### DIFF
--- a/src/cashel/blueprints/auth.py
+++ b/src/cashel/blueprints/auth.py
@@ -8,6 +8,7 @@ import time
 from flask import Blueprint, g, jsonify, redirect, render_template, request, session, url_for
 
 from cashel._helpers import _require_role
+from cashel.db import get_conn
 from cashel.settings import get_settings, save_settings
 from cashel.user_store import (
     UserValidationError,
@@ -23,8 +24,37 @@ from cashel.user_store import (
 
 auth_bp = Blueprint("auth", __name__)
 
-# In-memory lockout: {username_lower: (attempts, lockout_until)}
-_lockout: dict = {}
+_LOCKOUT_THRESHOLD = 5
+_LOCKOUT_SECONDS = 300  # 5 minutes
+
+
+def _get_lockout(username: str) -> tuple[int, float]:
+    row = get_conn().execute(
+        "SELECT attempts, lockout_until FROM login_attempts WHERE username = ?",
+        (username.lower(),),
+    ).fetchone()
+    if row:
+        return row["attempts"], row["lockout_until"]
+    return 0, 0.0
+
+
+def _record_failed_login(username: str) -> None:
+    conn = get_conn()
+    attempts, _ = _get_lockout(username)
+    attempts += 1
+    lockout_until = time.time() + _LOCKOUT_SECONDS if attempts >= _LOCKOUT_THRESHOLD else 0.0
+    conn.execute(
+        "INSERT INTO login_attempts (username, attempts, lockout_until) VALUES (?, ?, ?) "
+        "ON CONFLICT(username) DO UPDATE SET attempts=excluded.attempts, lockout_until=excluded.lockout_until",
+        (username.lower(), attempts, lockout_until),
+    )
+    conn.commit()
+
+
+def _clear_lockout(username: str) -> None:
+    conn = get_conn()
+    conn.execute("DELETE FROM login_attempts WHERE username = ?", (username.lower(),))
+    conn.commit()
 
 
 # ── Login / Logout ─────────────────────────────────────────────────────────────
@@ -45,8 +75,7 @@ def login_post():
     if not username or not password:
         return render_template("login.html", error="Username and password are required."), 401
 
-    key = username.lower()
-    attempts, lockout_until = _lockout.get(key, (0, 0))
+    attempts, lockout_until = _get_lockout(username)
     if lockout_until and time.time() < lockout_until:
         remaining = int(lockout_until - time.time())
         return render_template(
@@ -55,20 +84,17 @@ def login_post():
 
     user = check_password(username, password)
     if user:
-        _lockout.pop(key, None)
+        _clear_lockout(username)
         session.clear()
         session["authenticated"] = True
         session["user_id"] = user["id"]
         session["last_seen"] = time.time()
         next_url = request.args.get("next", "")
-        # Guard against open-redirect: only accept relative paths
         if next_url and next_url.startswith("/") and not next_url.startswith("//"):
             return redirect(next_url)
         return redirect(url_for("index"))
     else:
-        attempts += 1
-        lockout_until_new = time.time() + 300 if attempts >= 5 else 0
-        _lockout[key] = (attempts, lockout_until_new)
+        _record_failed_login(username)
         return render_template("login.html", error="Invalid username or password."), 401
 
 
@@ -115,11 +141,9 @@ def setup_post():
     except UserValidationError as exc:
         return render_template("setup.html", errors=[str(exc)], username=username), 400
 
-    # Enable auth
     settings = get_settings()
     save_settings({**settings, "auth_enabled": True})
 
-    # Auto-login the new admin
     session.clear()
     session["authenticated"] = True
     session["user_id"] = user["id"]
@@ -153,7 +177,6 @@ def create_user_route():
 @auth_bp.route("/auth/users/<user_id>", methods=["DELETE"])
 @_require_role("admin")
 def delete_user_route(user_id):
-    # Prevent self-deletion
     current = getattr(g, "current_user", None)
     if current and current.get("id") == user_id:
         return jsonify({"error": "Cannot delete your own account."}), 400

--- a/src/cashel/blueprints/history.py
+++ b/src/cashel/blueprints/history.py
@@ -5,6 +5,7 @@ import uuid
 
 from flask import Blueprint, Response, jsonify, request, send_file
 
+from cashel._helpers import _require_role
 from cashel.web import limiter  # noqa: F401
 from cashel.archive import (
     save_audit,
@@ -55,6 +56,7 @@ def archive_get(entry_id):
 
 
 @history_bp.route("/archive/<entry_id>", methods=["DELETE"])
+@_require_role("admin", "auditor")
 def archive_delete(entry_id):
     deleted = delete_entry(entry_id)
     return jsonify({"deleted": deleted})
@@ -191,12 +193,14 @@ def activity_list():
 
 
 @history_bp.route("/activity/<event_id>", methods=["DELETE"])
+@_require_role("admin")
 def activity_delete(event_id):
     deleted = delete_activity_entry(event_id)
     return jsonify({"deleted": deleted})
 
 
 @history_bp.route("/activity/clear", methods=["POST"])
+@_require_role("admin")
 def activity_clear():
     count = clear_activity()
     return jsonify({"cleared": count})

--- a/src/cashel/blueprints/settings_bp.py
+++ b/src/cashel/blueprints/settings_bp.py
@@ -20,6 +20,7 @@ settings_bp = Blueprint("settings_bp", __name__)
 
 
 @settings_bp.route("/license/activate", methods=["POST"])
+@_require_role("admin")
 def license_activate():
     key = request.form.get("key", "").strip()
     success, message = activate_license(key)
@@ -27,6 +28,7 @@ def license_activate():
 
 
 @settings_bp.route("/license/deactivate", methods=["POST"])
+@_require_role("admin")
 def license_deactivate():
     success, message = deactivate_license()
     return jsonify({"success": success, "message": message})
@@ -39,6 +41,7 @@ def license_status():
 
 
 @settings_bp.route("/settings", methods=["GET"])
+@_require_role("admin")
 def settings_get():
     s = get_settings()
     return jsonify(s)

--- a/src/cashel/db.py
+++ b/src/cashel/db.py
@@ -92,6 +92,12 @@ def init_db() -> None:
         );
 
         CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username);
+
+        CREATE TABLE IF NOT EXISTS login_attempts (
+            username      TEXT PRIMARY KEY,
+            attempts      INTEGER NOT NULL DEFAULT 0,
+            lockout_until REAL NOT NULL DEFAULT 0
+        );
     """)
     conn.commit()
     _migrate_json_to_sqlite()

--- a/src/cashel/static/style.css
+++ b/src/cashel/static/style.css
@@ -214,6 +214,27 @@ body {
 
 .badge-btn:hover .badge { opacity: 0.85; }
 
+/* ===== Header user / logout ===== */
+.header-user {
+  color: rgba(255,255,255,0.75);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.btn-logout {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 6px;
+  color: rgba(255,255,255,0.85);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.28rem 0.75rem;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.btn-logout:hover { background: rgba(255,255,255,0.18); }
+
 .badge-active    { background: rgba(68,187,136,0.2);  color: #44BB88; border: 1px solid #44BB88; }
 .badge-unlicensed{ background: rgba(255,170,0,0.15);  color: #FFAA00; border: 1px solid #FFAA00; }
 

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -48,6 +48,13 @@
             <span class="badge badge-unlicensed" id="licenseBadge">&#9888; Unlicensed</span>
           {% endif %}
         </button>
+        {% if current_user and not demo_mode %}
+        <span class="header-user" title="Signed in as {{ current_user.username }} ({{ current_user.role }})">&#128100; {{ current_user.username }}</span>
+        <form method="post" action="/logout" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn-logout" title="Sign out">Sign out</button>
+        </form>
+        {% endif %}
       </div>
     </div>
   </header>
@@ -1139,7 +1146,7 @@
   </main>
 
   <footer class="footer">
-    <p>Cashel v1.3 &mdash; Firewall Security Auditor</p>
+    <p>Cashel v1.4 &mdash; Firewall Security Auditor</p>
   </footer>
 
   <script nonce="{{ g.csp_nonce }}">
@@ -1736,7 +1743,7 @@
       version: "2.1.0",
       "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
       runs: [{
-        tool: {driver: {name:"Cashel", version:"1.2", informationUri:"https://github.com/Shamrock13/cashel", rules: Object.values(seenRules)}},
+        tool: {driver: {name:"Cashel", version:"1.4", informationUri:"https://github.com/Shamrock13/cashel", rules: Object.values(seenRules)}},
         results,
       }],
     };

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -28,9 +28,6 @@ def _tmp_db(fn):
             db_mod.DB_PATH = tmp
             db_mod._local.conn = None
             db_mod.init_db()
-            # Also reset the lockout dict between tests
-            import cashel.blueprints.auth as auth_bp_mod
-            auth_bp_mod._lockout.clear()
             return fn(*args, **kwargs)
         finally:
             conn = getattr(db_mod._local, "conn", None)
@@ -216,9 +213,6 @@ class TestWebAuth(unittest.TestCase):
         db_mod.DB_PATH = tmp
         db_mod._local.conn = None
         db_mod.init_db()
-
-        import cashel.blueprints.auth as auth_bp_mod
-        auth_bp_mod._lockout.clear()
 
         client = _make_client()
         return client, tmp, orig_path, orig_conn


### PR DESCRIPTION
## Summary

Fixes found during staging validation of v1.4.0:

- **Logout button missing** — added username display and Sign out button to app header; CSS styles added
- **Lockout not surviving restarts** — moved from in-memory dict to `login_attempts` SQLite table; survives Render worker restarts
- **Settings role gaps** — `GET /settings`, `/license/activate`, `/license/deactivate` now require `admin` role; previously accessible to all authenticated users
- **History role gaps** — `DELETE /archive/<id>` now requires admin/auditor; `DELETE /activity/<id>` and `POST /activity/clear` now require admin
- **Version strings** — footer `v1.3` and SARIF driver `1.2` bumped to `1.4` (missed in initial version bump)

## Test plan

- [ ] Render staging deploys cleanly
- [ ] Sign out button visible in header after login; clicking it returns to login page
- [ ] Username shown in header next to sign out button
- [ ] Wrong password 5× → locked out; refresh after lock still shows lockout message
- [ ] Viewer/auditor cannot access SMTP settings (Settings tab should be hidden or return 403)
- [ ] Viewer cannot clear activity log
- [ ] Footer shows `v1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)