### PR TITLE
fix: share Flask SECRET_KEY across gunicorn workers

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -7,6 +7,13 @@ created after forking and survive correctly.
 """
 
 import os
+import secrets as _secrets
+
+# Ensure all workers share the same Flask SECRET_KEY.
+# Without this, each worker generates its own random key (web.py fallback),
+# causing session cookies signed by one worker to be rejected by another.
+if not os.environ.get("CASHEL_SECRET"):
+    os.environ["CASHEL_SECRET"] = _secrets.token_hex(32)
 
 # ── Server ────────────────────────────────────────────────────────────────────
 bind = f"0.0.0.0:{os.environ.get('PORT', '5000')}"

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -2582,6 +2582,7 @@
   async function loadSettings() {
     try {
       const res = await fetch("/settings");
+      if (!res.ok) return;  // viewer (and other non-admin roles) get 403 — skip silently
       appSettings = await res.json();
       applySettingsToUI();
       applySettingsToForm();
@@ -2640,12 +2641,16 @@
   });
 
   function applySettingsToForm() {
-    document.getElementById("report").checked  = !!appSettings.auto_pdf;
-    document.getElementById("archive").checked = !!appSettings.auto_archive;
+    const reportEl  = document.getElementById("report");
+    const archiveEl = document.getElementById("archive");
+    if (reportEl)  reportEl.checked  = !!appSettings.auto_pdf;
+    if (archiveEl) archiveEl.checked = !!appSettings.auto_archive;
     const comp = appSettings.default_compliance || "";
     if (comp) {
-      document.getElementById("compliance").value     = comp;
-      document.getElementById("connCompliance").value = comp;
+      const compEl     = document.getElementById("compliance");
+      const connCompEl = document.getElementById("connCompliance");
+      if (compEl)     compEl.value     = comp;
+      if (connCompEl) connCompEl.value = comp;
     }
   }
 


### PR DESCRIPTION
## Root Cause

`gunicorn.conf.py` defaults to 2 workers with `preload_app = False`. Each worker independently imports `web.py`, which calls `secrets.token_hex(32)` as a fallback when `CASHEL_SECRET` is not set. Two workers → two different keys.

When a user logs in (worker 1 signs the session cookie) then makes an AJAX request (worker 2 tries to verify with its different key), Flask rejects the session as invalid. The request redirects to `/login`. `fetch()` follows the redirect, `res.json()` throws a SyntaxError on the HTML body, and the history/schedules tab renders "Failed to load…".

This affected all roles on Render staging where `CASHEL_SECRET` was not set as an env var.

## Fix

Generate `CASHEL_SECRET` once in the gunicorn master process before workers fork. Workers inherit the environment, so all workers share the same key. An existing `CASHEL_SECRET` env var is always respected and takes precedence.

## Also fixed (found during investigation)

- `loadSettings()`: early return on non-200 response — viewer gets 403 from `GET /settings` (admin-only endpoint); previously this set `appSettings = {error: "Insufficient permissions."}` which corrupted all downstream settings reads
- `applySettingsToForm()`: null guards on `report`, `archive`, `compliance`, `connCompliance` — these elements are Jinja2-gated to admin/auditor and are absent from viewer's DOM

## Test plan

- [ ] Log in as viewer on staging after deploy
- [ ] Click History tab → list loads (not "Failed to load…")
- [ ] Click Schedules tab → list loads
- [ ] Verify admin and auditor still work normally
- [ ] Confirm `CASHEL_SECRET` env var on Render still takes precedence if set

🤖 Generated with [Claude Code](https://claude.com/claude-code)