### PR TITLE
fix: null-guard paginationEl for viewer role

### DIFF
--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -1418,6 +1418,7 @@
 
   function renderPaginationBar(total, totalPages) {
     const el = document.getElementById("findingsPagination");
+    if (!el) return;
     // Show the bar whenever total > 10 (so page size selector is always accessible)
     if (allFindings.length <= 10) { el.classList.add("hidden"); return; }
     el.classList.remove("hidden");
@@ -1464,16 +1465,18 @@
   };
   (function () {
     const paginationEl = document.getElementById("findingsPagination");
-    paginationEl.addEventListener("click", function (e) {
-      const btn = e.target.closest(".btn-page");
-      if (!btn || btn.disabled) return;
-      const page = parseInt(btn.dataset.page, 10);
-      if (!isNaN(page)) window.goToPage(page);
-    });
-    paginationEl.addEventListener("change", function (e) {
-      const sel = e.target.closest(".page-size-select");
-      if (sel) window.changePageSize(+sel.value);
-    });
+    if (paginationEl) {
+      paginationEl.addEventListener("click", function (e) {
+        const btn = e.target.closest(".btn-page");
+        if (!btn || btn.disabled) return;
+        const page = parseInt(btn.dataset.page, 10);
+        if (!isNaN(page)) window.goToPage(page);
+      });
+      paginationEl.addEventListener("change", function (e) {
+        const sel = e.target.closest(".page-size-select");
+        if (sel) window.changePageSize(+sel.value);
+      });
+    }
   })();
   window.setFindingsView = function(mode) {
     compactView = mode === "compact";


### PR DESCRIPTION
## Root cause

`findingsPagination` is rendered inside the `{% if role in ('admin', 'auditor') %}` Jinja2 block. For viewers, the element doesn't exist in the DOM. An IIFE at page-load time called `.addEventListener` directly on the null result, producing:

> TypeError: null is not an object (evaluating 'paginationEl.addEventListener')

## Changes

- **IIFE (line ~1466):** Wrapped both `addEventListener` calls in `if (paginationEl)` — eliminates the crash entirely for viewer logins
- **`renderPaginationBar`:** Added `if (!el) return` early exit — closes a latent crash path if the function is ever reached without the element present

## Test plan

- [ ] Log in as viewer — no console errors on page load
- [ ] Log in as admin/auditor — pagination still functions normally
- [ ] Run an audit as admin, paginate results — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)