### PR TITLE
fix: skip loadSettings() for non-admin roles (suppress 403 console noise)

### DIFF
--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -1418,6 +1418,7 @@
 
   function renderPaginationBar(total, totalPages) {
     const el = document.getElementById("findingsPagination");
+    if (!el) return;
     // Show the bar whenever total > 10 (so page size selector is always accessible)
     if (allFindings.length <= 10) { el.classList.add("hidden"); return; }
     el.classList.remove("hidden");
@@ -1464,16 +1465,18 @@
   };
   (function () {
     const paginationEl = document.getElementById("findingsPagination");
-    paginationEl.addEventListener("click", function (e) {
-      const btn = e.target.closest(".btn-page");
-      if (!btn || btn.disabled) return;
-      const page = parseInt(btn.dataset.page, 10);
-      if (!isNaN(page)) window.goToPage(page);
-    });
-    paginationEl.addEventListener("change", function (e) {
-      const sel = e.target.closest(".page-size-select");
-      if (sel) window.changePageSize(+sel.value);
-    });
+    if (paginationEl) {
+      paginationEl.addEventListener("click", function (e) {
+        const btn = e.target.closest(".btn-page");
+        if (!btn || btn.disabled) return;
+        const page = parseInt(btn.dataset.page, 10);
+        if (!isNaN(page)) window.goToPage(page);
+      });
+      paginationEl.addEventListener("change", function (e) {
+        const sel = e.target.closest(".page-size-select");
+        if (sel) window.changePageSize(+sel.value);
+      });
+    }
   })();
   window.setFindingsView = function(mode) {
     compactView = mode === "compact";

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -2947,8 +2947,9 @@
   {% endif %}
   {% endif %}
 
-  // Load settings on startup and apply defaults to the audit form
-  loadSettings();
+  // Load settings on startup — admin only; non-admin roles get 403 and have
+  // sensible JS-side defaults (auto_pdf:false, auto_archive:false, default_compliance:"")
+  if (userRole === 'admin') loadSettings();
 
   {% if demo_mode %}
   // ── Demo mode: audit single-file picker (cards already in DOM) ──────────────


### PR DESCRIPTION
## Summary

- `GET /settings` returns 403 for auditor and viewer roles
- `loadSettings()` was called unconditionally at page load, triggering that 403 for every non-admin login and logging a browser console error
- Non-admin roles don't use the settings form; JS-side defaults (`auto_pdf: false`, `auto_archive: false`, `default_compliance: ""`) are correct for them
- Fix: gate `loadSettings()` behind `if (userRole === 'admin')` — no fetch is made, no console noise

## Test plan

- [ ] Log in as auditor — no 403 in console, audit form loads with defaults
- [ ] Log in as viewer — no 403 in console
- [ ] Log in as admin — settings load normally, audit form pre-filled from saved settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)