### PR TITLE
v1.5.0: auth audit log, OpenAPI docs, deployment guide

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,303 @@
+# Cashel — Production Deployment Guide
+
+This guide covers deploying Cashel behind a TLS-terminating reverse proxy. The app is a standard WSGI service running under Gunicorn — any proxy that can forward HTTP/1.1 will work.
+
+> **Homelab users:** `docker compose up` works out of the box with no proxy, no RBAC, and no TLS. Everything below is additive — none of it is mandatory.
+
+---
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Environment variables](#environment-variables)
+- [Docker Compose with nginx (primary)](#docker-compose-with-nginx)
+- [Docker Compose with Caddy (alternative)](#docker-compose-with-caddy)
+- [First-run admin setup](#first-run-admin-setup)
+- [Persistent volumes](#persistent-volumes)
+- [Upgrade procedure](#upgrade-procedure)
+- [Health check](#health-check)
+- [Hardening checklist](#hardening-checklist)
+
+---
+
+## Prerequisites
+
+- Docker ≥ 24 and Docker Compose v2 (`docker compose`)
+- A domain name with DNS pointed at your server (for TLS)
+- Ports 80 and 443 open on the host firewall
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CASHEL_SECRET` | **Yes** | — | Flask `SECRET_KEY`. Generate with `openssl rand -hex 32`. Sessions survive restarts only when this is set. |
+| `CASHEL_KEY_FILE` | **Yes** | `~/.config/cashel/cashel.key` | Path to the Fernet encryption key used to encrypt stored SSH passwords and API keys. Must persist across restarts. |
+| `CASHEL_DB` | No | `/data/cashel.db` | SQLite database path. |
+| `CASHEL_SECURE_COOKIES` | No | `false` | Set to `true` when serving over HTTPS. Marks session cookie with `Secure` flag. |
+| `WEB_CONCURRENCY` | No | `1` | Gunicorn worker count. Keep at `1` on single-CPU hosts to avoid OOM. |
+| `PORT` | No | `5000` | Internal port Gunicorn binds to (do not expose directly). |
+
+Generate required secrets:
+
+```bash
+# Flask session key
+openssl rand -hex 32
+
+# Fernet encryption key (base64-encoded 32-byte key)
+python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+---
+
+## Docker Compose with nginx
+
+This is the recommended production setup. nginx handles TLS, and Cashel runs on an internal network not exposed to the internet.
+
+### Directory layout
+
+```
+cashel-prod/
+  docker-compose.yml
+  nginx/
+    nginx.conf
+  data/           # SQLite DB (created on first run, must persist)
+  keys/           # Fernet key file (must persist)
+```
+
+### `docker-compose.yml`
+
+```yaml
+services:
+  cashel:
+    image: ghcr.io/shamrock13/cashel:latest
+    restart: unless-stopped
+    environment:
+      CASHEL_SECRET: "${CASHEL_SECRET}"
+      CASHEL_KEY_FILE: /keys/cashel.key
+      CASHEL_DB: /data/cashel.db
+      CASHEL_SECURE_COOKIES: "true"
+      WEB_CONCURRENCY: "1"
+    volumes:
+      - ./data:/data
+      - ./keys:/keys
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro   # certbot-managed certs
+    networks:
+      - internal
+    depends_on:
+      - cashel
+
+networks:
+  internal:
+    driver: bridge
+```
+
+### `nginx/nginx.conf`
+
+```nginx
+events {}
+
+http {
+    # Redirect HTTP → HTTPS
+    server {
+        listen 80;
+        server_name cashel.example.com;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name cashel.example.com;
+
+        ssl_certificate     /etc/letsencrypt/live/cashel.example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/cashel.example.com/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        # Pass real client IP to Cashel (needed for rate limiting and audit logs)
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header Host            $host;
+
+        location / {
+            proxy_pass         http://cashel:5000;
+            proxy_http_version 1.1;
+            proxy_read_timeout 120s;
+            client_max_body_size 50M;
+        }
+    }
+}
+```
+
+Obtain a certificate with Certbot before starting nginx:
+
+```bash
+certbot certonly --standalone -d cashel.example.com
+```
+
+### Start
+
+```bash
+# Set secrets in the shell (or use a .env file)
+export CASHEL_SECRET="$(openssl rand -hex 32)"
+
+# Create the Fernet key on first deploy only — never regenerate it afterwards
+python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())" \
+  > keys/cashel.key
+
+docker compose up -d
+```
+
+---
+
+## Docker Compose with Caddy
+
+Caddy handles TLS automatically via ACME/Let's Encrypt — no manual certificate management.
+
+```yaml
+services:
+  cashel:
+    image: ghcr.io/shamrock13/cashel:latest
+    restart: unless-stopped
+    environment:
+      CASHEL_SECRET: "${CASHEL_SECRET}"
+      CASHEL_KEY_FILE: /keys/cashel.key
+      CASHEL_DB: /data/cashel.db
+      CASHEL_SECURE_COOKIES: "true"
+    volumes:
+      - ./data:/data
+      - ./keys:/keys
+    networks:
+      - internal
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - internal
+    depends_on:
+      - cashel
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+**`Caddyfile`:**
+
+```
+cashel.example.com {
+    reverse_proxy cashel:5000 {
+        header_up X-Forwarded-For {remote_host}
+    }
+}
+```
+
+Caddy fetches and renews the certificate automatically on first request.
+
+---
+
+## First-Run Admin Setup
+
+On first boot with an empty database, Cashel redirects all requests to `/setup`. Open a browser and navigate to your domain — you'll be prompted to create the first admin account.
+
+After setup, auth is enabled automatically. Store the admin credentials somewhere safe — there is no password recovery route (you can reset via the admin users API if you have another admin account).
+
+---
+
+## Persistent Volumes
+
+Two paths **must** survive container restarts and re-deploys:
+
+| Path | Contents | Risk if lost |
+|---|---|---|
+| `/data/cashel.db` | All audits, history, users, schedules, settings | **All data lost** |
+| `/keys/cashel.key` (or `CASHEL_KEY_FILE`) | Fernet encryption key | Encrypted SSH passwords and API keys become unreadable |
+
+Back up both. The database is a single SQLite file — a simple `cp` or `rsync` is sufficient.
+
+```bash
+# Quick backup
+cp data/cashel.db "backups/cashel_$(date +%Y%m%d).db"
+```
+
+---
+
+## Upgrade Procedure
+
+1. Pull the new image:
+   ```bash
+   docker compose pull cashel
+   ```
+2. Restart the container (SQLite schema migrations run automatically on startup):
+   ```bash
+   docker compose up -d cashel
+   ```
+3. Verify health:
+   ```bash
+   curl https://cashel.example.com/health
+   ```
+
+No manual database migrations are required. The schema uses `CREATE TABLE IF NOT EXISTS` — new tables and columns are added automatically on startup.
+
+---
+
+## Health Check
+
+`GET /health` is always public (no authentication required).
+
+```json
+{
+  "ok": true,
+  "version": "1.4.0",
+  "uptime_seconds": 3600,
+  "scheduler_running": true,
+  "last_audit_at": "2026-04-10T14:32:00Z"
+}
+```
+
+Use this endpoint for container health checks, load balancer probes, and uptime monitoring.
+
+---
+
+## Hardening Checklist
+
+- [ ] `CASHEL_SECRET` is set and not the default
+- [ ] `CASHEL_KEY_FILE` points to a persistent, backed-up location
+- [ ] `CASHEL_SECURE_COOKIES=true` when behind HTTPS
+- [ ] TLS 1.2+ only on the proxy (TLS 1.3 preferred)
+- [ ] `/data` volume is backed up regularly
+- [ ] Fernet key (`cashel.key`) is backed up separately from the database
+- [ ] Admin account uses a strong password (≥ 12 characters, enforced)
+- [ ] `WEB_CONCURRENCY=1` on single-CPU hosts (prevents OOM under Gunicorn)
+- [ ] Port 5000 is not exposed directly — proxy handles all inbound traffic
+- [ ] HSTS header enabled at the proxy layer (`Strict-Transport-Security: max-age=31536000`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "apscheduler>=3.10,<4.0",
     "defusedxml>=0.7,<1.0",
     "gunicorn>=22.0,<24.0",
+    "flasgger>=0.9,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ paramiko>=3.0,<4.0
 apscheduler>=3.10,<4.0
 defusedxml>=0.7,<1.0
 gunicorn>=22.0,<24.0
+flasgger>=0.9,<1.0

--- a/src/cashel/_helpers.py
+++ b/src/cashel/_helpers.py
@@ -46,6 +46,10 @@ _AUTH_EXEMPT_ENDPOINTS = {
     "static",
 }
 
+# Path prefixes that bypass auth (Swagger UI and spec JSON — public API docs)
+# Path prefixes exempt from auth — Swagger UI + spec JSON are always public
+_AUTH_EXEMPT_PATH_PREFIXES = ("/api/docs", "/flasgger_static/", "/apispec")
+
 
 def _require_auth_impl(demo_mode: bool):
     """Core auth gate — called by web.py's app.before_request hook."""
@@ -70,6 +74,9 @@ def _require_auth_impl(demo_mode: bool):
     if request.endpoint in _AUTH_EXEMPT_ENDPOINTS:
         return
 
+    if request.path.startswith(_AUTH_EXEMPT_PATH_PREFIXES):
+        return
+
     # API key auth (X-API-Key header or ?api_key= param) — CI/CLI
     api_key_header = request.headers.get("X-API-Key") or request.args.get("api_key")
     if api_key_header:
@@ -80,6 +87,9 @@ def _require_auth_impl(demo_mode: bool):
             g.auth_method = "api_key"
             g.current_user = user
             return
+        from .auth_audit import log_auth_event, AUTH_INVALID_API_KEY
+        log_auth_event(AUTH_INVALID_API_KEY, success=False,
+                       details={"endpoint": request.path})
         if request.path.startswith("/api/"):
             return jsonify(
                 {"ok": False, "data": None, "error": "Invalid API key."}

--- a/src/cashel/auth_audit.py
+++ b/src/cashel/auth_audit.py
@@ -1,0 +1,95 @@
+"""Auth audit log — record security events (logins, key failures, user changes).
+
+Follows the same pattern as activity_log.py but targets the auth_events table.
+"""
+
+import json
+import uuid
+from datetime import datetime
+
+from flask import has_request_context
+from flask import request as _flask_request
+
+from .db import get_conn
+
+# Event type constants
+AUTH_LOGIN_SUCCESS = "login_success"
+AUTH_LOGIN_FAILURE = "login_failure"
+AUTH_ACCOUNT_LOCKOUT = "account_lockout"
+AUTH_LOGOUT = "logout"
+AUTH_INVALID_API_KEY = "invalid_api_key"
+AUTH_USER_CREATED = "user_created"
+AUTH_USER_DELETED = "user_deleted"
+AUTH_PASSWORD_CHANGED = "password_changed"
+AUTH_API_KEY_GENERATED = "api_key_generated"
+AUTH_API_KEY_REVOKED = "api_key_revoked"
+AUTH_SETTINGS_CHANGED = "settings_changed"
+AUTH_LICENSE_CHANGED = "license_changed"
+
+
+def log_auth_event(
+    event: str,
+    actor: str = "",
+    target: str = "",
+    success: bool = True,
+    details: dict | None = None,
+) -> str:
+    """Append a security event. Returns the new event ID."""
+    event_id = uuid.uuid4().hex[:12]
+    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    ip = ""
+    ua = ""
+    if has_request_context():
+        # Prefer X-Real-IP set by nginx/Caddy so logs show the real client IP,
+        # not the proxy's loopback address.
+        ip = (_flask_request.headers.get("X-Real-IP")
+              or _flask_request.remote_addr
+              or "")
+        ua = _flask_request.headers.get("User-Agent", "")[:256]
+
+    conn = get_conn()
+    conn.execute(
+        """
+        INSERT INTO auth_events
+            (id, event, actor, target, ip_address, user_agent, success, details, timestamp)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            event,
+            actor or "",
+            target or "",
+            ip,
+            ua,
+            1 if success else 0,
+            json.dumps(details or {}),
+            timestamp,
+        ),
+    )
+    conn.commit()
+    return event_id
+
+
+def list_auth_events(limit: int = 200) -> list:
+    """Return auth events sorted newest-first, up to limit entries."""
+    conn = get_conn()
+    rows = conn.execute(
+        "SELECT * FROM auth_events ORDER BY timestamp DESC LIMIT ?", (limit,)
+    ).fetchall()
+    return [_row_to_dict(row) for row in rows]
+
+
+def clear_auth_events() -> int:
+    """Delete all auth event entries. Returns count deleted."""
+    conn = get_conn()
+    cur = conn.execute("DELETE FROM auth_events")
+    conn.commit()
+    return cur.rowcount
+
+
+def _row_to_dict(row) -> dict:
+    d = dict(row)
+    d["success"] = bool(d["success"])
+    d["details"] = json.loads(d["details"]) if d.get("details") else {}
+    return d

--- a/src/cashel/blueprints/api_v1.py
+++ b/src/cashel/blueprints/api_v1.py
@@ -41,7 +41,87 @@ def _api_err(message, status=400):
 @api_bp.route("/audit", methods=["POST"])
 @limiter.limit("30/minute")
 def api_audit():
-    """POST /api/v1/audit — audit a config file, returns findings + summary."""
+    """Audit a firewall config file and return findings with a security score.
+    ---
+    tags:
+      - Audit
+    consumes:
+      - multipart/form-data
+    parameters:
+      - name: config
+        in: formData
+        type: file
+        required: true
+        description: Firewall configuration file to audit.
+      - name: vendor
+        in: formData
+        type: string
+        required: false
+        default: auto
+        description: "Vendor hint. One of: auto, asa, ftd, fortinet, paloalto, pfsense, juniper, iptables, nftables, aws, azure, gcp."
+      - name: compliance
+        in: formData
+        type: string
+        required: false
+        description: "Optional compliance framework: cis, nist, pci, hipaa, stig, soc2."
+      - name: archive
+        in: formData
+        type: string
+        required: false
+        default: "1"
+        description: "Set to '0' to skip saving the result to audit history."
+      - name: tag
+        in: formData
+        type: string
+        required: false
+        description: Optional label for grouping audits (e.g. device hostname).
+    security:
+      - ApiKeyHeader: []
+    responses:
+      200:
+        description: Audit completed successfully.
+        schema:
+          type: object
+          properties:
+            ok:
+              type: boolean
+            data:
+              type: object
+              properties:
+                archive_id:
+                  type: string
+                  description: ID of the saved audit entry, or null if not archived.
+                vendor:
+                  type: string
+                summary:
+                  type: object
+                  properties:
+                    high:
+                      type: integer
+                    medium:
+                      type: integer
+                    total:
+                      type: integer
+                    score:
+                      type: integer
+                      description: Security score 0–100.
+                findings:
+                  type: array
+                  items:
+                    type: string
+                detected_hostname:
+                  type: string
+            error:
+              type: string
+      400:
+        description: Missing or invalid parameters.
+      401:
+        description: Authentication required.
+      413:
+        description: File exceeds the 5 MB limit.
+      429:
+        description: Rate limit exceeded (30 requests/minute).
+    """
     if "config" not in request.files or not request.files["config"].filename:
         return _api_err("config file is required")
 
@@ -124,7 +204,33 @@ def api_audit():
 
 @api_bp.route("/audit/<entry_id>", methods=["GET"])
 def api_audit_get(entry_id):
-    """GET /api/v1/audit/<id> — retrieve a specific archived audit result."""
+    """Retrieve a specific archived audit result by ID.
+    ---
+    tags:
+      - Audit
+    parameters:
+      - name: entry_id
+        in: path
+        type: string
+        required: true
+        description: Audit entry ID returned by POST /api/v1/audit.
+    security:
+      - ApiKeyHeader: []
+    responses:
+      200:
+        description: Audit entry found.
+        schema:
+          type: object
+          properties:
+            ok:
+              type: boolean
+            data:
+              type: object
+            error:
+              type: string
+      404:
+        description: Audit entry not found.
+    """
     entry = get_entry(entry_id)
     if not entry:
         return _api_err("Audit not found.", 404)
@@ -133,9 +239,39 @@ def api_audit_get(entry_id):
 
 @api_bp.route("/audit/<entry_id>/remediation-plan", methods=["GET"])
 def api_remediation_plan(entry_id):
-    """GET /api/v1/audit/<id>/remediation-plan — generate remediation plan.
-
-    Query param: fmt = json | markdown  (default: json)
+    """Generate a remediation plan from an archived audit.
+    ---
+    tags:
+      - Audit
+    parameters:
+      - name: entry_id
+        in: path
+        type: string
+        required: true
+        description: Audit entry ID.
+      - name: fmt
+        in: query
+        type: string
+        required: false
+        default: json
+        description: "Output format: json or markdown."
+    security:
+      - ApiKeyHeader: []
+    responses:
+      200:
+        description: Remediation plan generated.
+        schema:
+          type: object
+          properties:
+            ok:
+              type: boolean
+            data:
+              type: object
+              description: Plan object (json) or {markdown string} depending on fmt.
+            error:
+              type: string
+      404:
+        description: Audit entry not found.
     """
     entry = get_entry(entry_id)
     if not entry:
@@ -159,7 +295,44 @@ def api_remediation_plan(entry_id):
 
 @api_bp.route("/history", methods=["GET"])
 def api_history():
-    """GET /api/v1/history — list audit history (metadata only, no findings)."""
+    """List audit history (metadata only, no findings payload).
+    ---
+    tags:
+      - History
+    parameters:
+      - name: limit
+        in: query
+        type: integer
+        required: false
+        default: 50
+        description: Maximum number of entries to return (max 500).
+      - name: vendor
+        in: query
+        type: string
+        required: false
+        description: Filter by vendor slug (e.g. asa, fortinet, paloalto).
+      - name: tag
+        in: query
+        type: string
+        required: false
+        description: Filter by tag label.
+    security:
+      - ApiKeyHeader: []
+    responses:
+      200:
+        description: List of audit history entries (slim, no findings).
+        schema:
+          type: object
+          properties:
+            ok:
+              type: boolean
+            data:
+              type: array
+              items:
+                type: object
+            error:
+              type: string
+    """
     try:
         limit = min(int(request.args.get("limit", 50)), 500)
     except (ValueError, TypeError):
@@ -182,7 +355,49 @@ def api_history():
 @api_bp.route("/diff", methods=["POST"])
 @limiter.limit("30/minute")
 def api_diff():
-    """POST /api/v1/diff — compare two config files."""
+    """Compare two firewall config files and return a structured diff.
+    ---
+    tags:
+      - Diff
+    consumes:
+      - multipart/form-data
+    parameters:
+      - name: config_a
+        in: formData
+        type: file
+        required: true
+        description: First (baseline) config file.
+      - name: config_b
+        in: formData
+        type: file
+        required: true
+        description: Second (current) config file.
+      - name: vendor
+        in: formData
+        type: string
+        required: false
+        default: auto
+        description: "Vendor hint. One of: auto, asa, ftd, fortinet, paloalto, etc."
+    security:
+      - ApiKeyHeader: []
+    responses:
+      200:
+        description: Diff result.
+        schema:
+          type: object
+          properties:
+            ok:
+              type: boolean
+            data:
+              type: object
+              description: Structured diff with added/removed/changed sections.
+            error:
+              type: string
+      400:
+        description: Missing files or invalid vendor.
+      429:
+        description: Rate limit exceeded (30 requests/minute).
+    """
     if "config_a" not in request.files or "config_b" not in request.files:
         return _api_err("config_a and config_b files are required.")
 

--- a/src/cashel/blueprints/auth.py
+++ b/src/cashel/blueprints/auth.py
@@ -17,6 +17,12 @@ from flask import (
 )
 
 from cashel._helpers import _require_role
+from cashel.auth_audit import (
+    AUTH_LOGIN_SUCCESS, AUTH_LOGIN_FAILURE, AUTH_ACCOUNT_LOCKOUT, AUTH_LOGOUT,
+    AUTH_USER_CREATED, AUTH_USER_DELETED, AUTH_PASSWORD_CHANGED,
+    AUTH_API_KEY_GENERATED, AUTH_API_KEY_REVOKED,
+    log_auth_event,
+)
 from cashel.db import get_conn
 from cashel.settings import get_settings, save_settings
 from cashel.user_store import (
@@ -95,6 +101,8 @@ def login_post():
     attempts, lockout_until = _get_lockout(username)
     if lockout_until and time.time() < lockout_until:
         remaining = int(lockout_until - time.time())
+        log_auth_event(AUTH_ACCOUNT_LOCKOUT, actor=username, success=False,
+                       details={"lockout_remaining_seconds": remaining})
         return render_template(
             "login.html", error=f"Account locked. Try again in {remaining}s."
         ), 429
@@ -102,6 +110,8 @@ def login_post():
     user = check_password(username, password)
     if user:
         _clear_lockout(username)
+        log_auth_event(AUTH_LOGIN_SUCCESS, actor=username,
+                       details={"role": user.get("role", "")})
         session.clear()
         session["authenticated"] = True
         session["user_id"] = user["id"]
@@ -112,11 +122,21 @@ def login_post():
         return redirect(url_for("index"))
     else:
         _record_failed_login(username)
+        log_auth_event(AUTH_LOGIN_FAILURE, actor=username, success=False,
+                       details={"reason": "invalid_credentials"})
         return render_template("login.html", error="Invalid username or password."), 401
 
 
 @auth_bp.route("/logout", methods=["POST"])
 def logout():
+    # g.current_user is None for exempt endpoints — read username from session instead
+    actor = ""
+    user_id = session.get("user_id")
+    if user_id:
+        from cashel.user_store import get_user_by_id
+        user = get_user_by_id(user_id)
+        actor = (user or {}).get("username", "")
+    log_auth_event(AUTH_LOGOUT, actor=actor)
     session.clear()
     return redirect(url_for("auth.login"))
 
@@ -158,6 +178,9 @@ def setup_post():
     except UserValidationError as exc:
         return render_template("setup.html", errors=[str(exc)], username=username), 400
 
+    log_auth_event(AUTH_USER_CREATED, actor=username, target=username,
+                   details={"role": "admin", "context": "first_run_setup"})
+
     settings = get_settings()
     save_settings({**settings, "auth_enabled": True})
 
@@ -184,10 +207,13 @@ def create_user_route():
     username = (data.get("username") or "").strip()
     password = data.get("password") or ""
     role = (data.get("role") or "viewer").strip()
+    actor = (getattr(g, "current_user", None) or {}).get("username", "")
     try:
         user = create_user(username, password, role)
     except UserValidationError as exc:
         return jsonify({"error": str(exc)}), 400
+    log_auth_event(AUTH_USER_CREATED, actor=actor, target=username,
+                   details={"role": role})
     return jsonify(user), 201
 
 
@@ -197,12 +223,18 @@ def delete_user_route(user_id):
     current = getattr(g, "current_user", None)
     if current and current.get("id") == user_id:
         return jsonify({"error": "Cannot delete your own account."}), 400
+    # Fetch target username before deletion for the audit log
+    from cashel.user_store import get_user_by_id
+    target_user = get_user_by_id(user_id)
+    target_username = (target_user or {}).get("username", user_id)
     try:
         deleted = delete_user(user_id)
     except UserValidationError as exc:
         return jsonify({"error": str(exc)}), 400
     if not deleted:
         return jsonify({"error": "User not found."}), 404
+    actor = (current or {}).get("username", "")
+    log_auth_event(AUTH_USER_DELETED, actor=actor, target=target_username)
     return jsonify({"deleted": True})
 
 
@@ -221,6 +253,8 @@ def change_password_route():
         change_password(current["id"], new_password)
     except UserValidationError as exc:
         return jsonify({"error": str(exc)}), 400
+    log_auth_event(AUTH_PASSWORD_CHANGED, actor=current.get("username", ""),
+                   target=current.get("username", ""))
     return jsonify({"ok": True})
 
 
@@ -232,6 +266,7 @@ def generate_api_key_route():
 
     plaintext = generate_api_key(current["id"])
     hint = ("csh_..." + plaintext[-4:]) if len(plaintext) >= 4 else ""
+    log_auth_event(AUTH_API_KEY_GENERATED, actor=current.get("username", ""))
     return jsonify({"ok": True, "api_key": plaintext, "api_key_hint": hint})
 
 
@@ -242,4 +277,5 @@ def revoke_api_key_route():
         return jsonify({"error": "Authentication required."}), 401
 
     revoke_api_key(current["id"])
+    log_auth_event(AUTH_API_KEY_REVOKED, actor=current.get("username", ""))
     return jsonify({"ok": True})

--- a/src/cashel/blueprints/history.py
+++ b/src/cashel/blueprints/history.py
@@ -19,6 +19,7 @@ from cashel.activity_log import (
     delete_activity_entry,
     clear_activity,
 )
+from cashel.auth_audit import list_auth_events, clear_auth_events
 from cashel.remediation import generate_plan, plan_to_markdown, plan_to_pdf
 
 REPORTS_FOLDER = os.environ.get("REPORTS_FOLDER", "/tmp/cashel_reports")
@@ -204,4 +205,25 @@ def activity_delete(event_id):
 @_require_role("admin")
 def activity_clear():
     count = clear_activity()
+    return jsonify({"cleared": count})
+
+
+# ── Security (auth event) log ──────────────────────────────────────────────────
+
+
+@history_bp.route("/auth-events", methods=["GET"])
+@_require_role("admin", "auditor")
+def auth_events_list():
+    """Return auth/security events, admin and auditor roles only."""
+    try:
+        limit = int(request.args.get("limit", 200))
+    except (ValueError, TypeError):
+        limit = 200
+    return jsonify(list_auth_events(limit=limit))
+
+
+@history_bp.route("/auth-events/clear", methods=["POST"])
+@_require_role("admin")
+def auth_events_clear():
+    count = clear_auth_events()
     return jsonify({"cleared": count})

--- a/src/cashel/blueprints/settings_bp.py
+++ b/src/cashel/blueprints/settings_bp.py
@@ -4,9 +4,12 @@ import smtplib
 import ssl
 from email.mime.text import MIMEText
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, g, jsonify, request
 
 from cashel._helpers import _require_role
+from cashel.auth_audit import (
+    AUTH_LICENSE_CHANGED, AUTH_SETTINGS_CHANGED, log_auth_event,
+)
 from cashel.license import (
     check_license,
     activate_license,
@@ -24,6 +27,9 @@ settings_bp = Blueprint("settings_bp", __name__)
 def license_activate():
     key = request.form.get("key", "").strip()
     success, message = activate_license(key)
+    actor = (getattr(g, "current_user", None) or {}).get("username", "")
+    log_auth_event(AUTH_LICENSE_CHANGED, actor=actor, success=success,
+                   details={"action": "activated", "message": message})
     return jsonify({"success": success, "message": message})
 
 
@@ -31,6 +37,9 @@ def license_activate():
 @_require_role("admin")
 def license_deactivate():
     success, message = deactivate_license()
+    actor = (getattr(g, "current_user", None) or {}).get("username", "")
+    log_auth_event(AUTH_LICENSE_CHANGED, actor=actor, success=success,
+                   details={"action": "deactivated", "message": message})
     return jsonify({"success": success, "message": message})
 
 
@@ -56,6 +65,9 @@ def settings_save():
     saved = save_settings(data)
     # Reconfigure syslog immediately when settings are changed.
     configure_syslog(saved)
+    actor = (getattr(g, "current_user", None) or {}).get("username", "")
+    log_auth_event(AUTH_SETTINGS_CHANGED, actor=actor,
+                   details={"keys_updated": list(data.keys())})
     return jsonify(saved)
 
 

--- a/src/cashel/db.py
+++ b/src/cashel/db.py
@@ -98,6 +98,19 @@ def init_db() -> None:
             attempts      INTEGER NOT NULL DEFAULT 0,
             lockout_until REAL NOT NULL DEFAULT 0
         );
+
+        CREATE TABLE IF NOT EXISTS auth_events (
+            id          TEXT PRIMARY KEY,
+            event       TEXT NOT NULL,             -- event type constant
+            actor       TEXT NOT NULL DEFAULT '',  -- username performing the action
+            target      TEXT NOT NULL DEFAULT '',  -- affected username (user mgmt events)
+            ip_address  TEXT NOT NULL DEFAULT '',
+            user_agent  TEXT NOT NULL DEFAULT '',
+            success     INTEGER NOT NULL DEFAULT 1,
+            details     TEXT NOT NULL DEFAULT '{}',  -- JSON blob
+            timestamp   TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_auth_events_ts ON auth_events(timestamp DESC);
     """)
     conn.commit()
     _migrate_json_to_sqlite()

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -543,6 +543,9 @@
         {% if not current_user or current_user.role == 'admin' %}
         <button class="sub-tab-btn" data-subtab="activity">&#128203; Activity Log</button>
         {% endif %}
+        {% if not current_user or current_user.role in ('admin', 'auditor') %}
+        <button class="sub-tab-btn" data-subtab="seclog">&#128274; Security Log</button>
+        {% endif %}
       </div>
 
       <!-- ── Audit History sub-tab ── -->
@@ -643,6 +646,29 @@
       </div><!-- /sub-activity -->
       {% else %}
       <div id="sub-activity" class="hidden"></div>
+      {% endif %}
+
+      <!-- ── Security Log sub-tab ── -->
+      {% if not current_user or current_user.role in ('admin', 'auditor') %}
+      <div id="sub-seclog" class="hidden">
+      <div class="card">
+        <div class="results-header">
+          <h2 class="card-title" style="margin-bottom:0">Security Log</h2>
+          <div style="display:flex;gap:0.5rem;align-items:center;">
+            <button class="btn-secondary" id="refreshSecLogBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#8635; Refresh</button>
+            {% if not current_user or current_user.role == 'admin' %}
+            <button class="btn-danger" id="clearSecLogBtn" style="font-size:0.8rem;padding:0.3rem 0.75rem">&#128465; Clear All</button>
+            {% endif %}
+          </div>
+        </div>
+        <p class="card-desc">Authentication events — logins, failures, invalid API keys, and user/settings changes.</p>
+        <div id="secLogList" class="history-list">
+          <p class="text-muted">Loading&hellip;</p>
+        </div>
+      </div>
+      </div><!-- /sub-seclog -->
+      {% else %}
+      <div id="sub-seclog" class="hidden"></div>
       {% endif %}
 
     </section>
@@ -1295,9 +1321,14 @@
   // ═══════════════════════════════════════ HISTORY SUB-TABS (audits/activity) ══
   function switchHistorySubTab(subtab) {
     document.querySelectorAll(".sub-tab-btn").forEach(b => b.classList.toggle("sub-tab-active", b.dataset.subtab === subtab));
-    document.getElementById("sub-audits").classList.toggle("hidden", subtab !== "audits");
-    document.getElementById("sub-activity").classList.toggle("hidden", subtab !== "activity");
+    const subAudits = document.getElementById("sub-audits");
+    const subActivity = document.getElementById("sub-activity");
+    const subSecLog = document.getElementById("sub-seclog");
+    if (subAudits) subAudits.classList.toggle("hidden", subtab !== "audits");
+    if (subActivity) subActivity.classList.toggle("hidden", subtab !== "activity");
+    if (subSecLog) subSecLog.classList.toggle("hidden", subtab !== "seclog");
     if (subtab === "activity") loadActivity();
+    if (subtab === "seclog") loadSecLog();
   }
   document.querySelectorAll(".sub-tab-btn").forEach(btn =>
     btn.addEventListener("click", () => switchHistorySubTab(btn.dataset.subtab))
@@ -2220,6 +2251,74 @@
     if (!confirm("Clear all activity log entries?")) return;
     await fetch("/activity/clear", { method: "POST" });
     await loadActivity();
+  });
+
+  // ══════════════════════════════════════════════════ SECURITY LOG ══
+  const SEC_EVENT_LABELS = {
+    login_success:     "Login",
+    login_failure:     "Login Failed",
+    account_lockout:   "Account Locked",
+    logout:            "Logout",
+    invalid_api_key:   "Invalid API Key",
+    user_created:      "User Created",
+    user_deleted:      "User Deleted",
+    password_changed:  "Password Changed",
+    api_key_generated: "API Key Generated",
+    api_key_revoked:   "API Key Revoked",
+    settings_changed:  "Settings Changed",
+    license_changed:   "License Changed",
+  };
+
+  async function loadSecLog() {
+    const el = document.getElementById("secLogList");
+    if (!el) return;
+    el.innerHTML = `<p class="text-muted">Loading&hellip;</p>`;
+    try {
+      const res    = await fetch("/auth-events");
+      const events = await res.json();
+      renderSecLog(events);
+    } catch (err) {
+      el.innerHTML = `<div class="alert alert-error">Failed to load security log: ${escHtml(err.message)}</div>`;
+    }
+  }
+
+  function renderSecLog(events) {
+    const el = document.getElementById("secLogList");
+    if (!el) return;
+    if (!events.length) {
+      el.innerHTML = `<p class="text-muted">No security events yet.</p>`;
+      return;
+    }
+    el.innerHTML = events.map(e => {
+      const ts     = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
+      const label  = SEC_EVENT_LABELS[e.event] || e.event;
+      const ok     = e.success;
+      const actor  = e.actor ? `<strong>${escHtml(e.actor)}</strong>` : "<em>unknown</em>";
+      const target = e.target ? ` → ${escHtml(e.target)}` : "";
+      const ip     = e.ip_address ? `<span class="history-meta">${escHtml(e.ip_address)}</span>` : "";
+      return `<div class="activity-entry ${ok ? "" : "activity-entry-fail"}">
+        <div class="activity-entry-left">
+          <span class="activity-action-badge">${escHtml(label)}</span>
+          <div class="history-entry-info">
+            <span class="history-filename">${actor}${target}</span>
+            <span class="history-meta">${escHtml(ts)}</span>
+            ${ip}
+          </div>
+        </div>
+        <div class="activity-entry-right">
+          <span class="${ok ? "activity-ok" : "activity-fail"}">${ok ? "&#10003;" : "&#10007;"}</span>
+        </div>
+      </div>`;
+    }).join("");
+  }
+
+  const _refreshSecLogBtn = document.getElementById("refreshSecLogBtn");
+  if (_refreshSecLogBtn) _refreshSecLogBtn.addEventListener("click", loadSecLog);
+  const _clearSecLogBtn = document.getElementById("clearSecLogBtn");
+  if (_clearSecLogBtn) _clearSecLogBtn.addEventListener("click", async function () {
+    if (!confirm("Clear all security log entries?")) return;
+    await fetch("/auth-events/clear", { method: "POST" });
+    await loadSecLog();
   });
 
   // ══════════════════════════════════════════════════════════ HELPERS ══

--- a/src/cashel/web.py
+++ b/src/cashel/web.py
@@ -4,7 +4,8 @@ import os
 import secrets
 import time
 
-from flask import Flask, g, jsonify, render_template
+from flask import Flask, g, jsonify, render_template, request
+from flasgger import Swagger
 
 from .extensions import csrf, limiter
 from .license import check_license, mask_key, DEMO_MODE
@@ -48,6 +49,43 @@ app.config["SESSION_COOKIE_SECURE"] = (
 csrf.init_app(app)
 limiter.init_app(app)
 
+_swagger = Swagger(app, config={
+    "headers": [],
+    "specs": [
+        {
+            "endpoint": "apispec",
+            "route": "/apispec.json",
+            "rule_filter": lambda rule: rule.rule.startswith("/api/v1"),
+            "model_filter": lambda tag: True,
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/api/docs",
+}, template={
+    "info": {
+        "title": "Cashel API",
+        "description": (
+            "Cashel firewall auditing REST API. "
+            "Authenticate with an `X-API-Key` header or `?api_key=` query parameter."
+        ),
+        "version": "1",
+    },
+    "securityDefinitions": {
+        "ApiKeyHeader": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-API-Key",
+        }
+    },
+    "security": [{"ApiKeyHeader": []}],
+    "tags": [
+        {"name": "Audit", "description": "Run and retrieve audits"},
+        {"name": "History", "description": "Browse audit history"},
+        {"name": "Diff", "description": "Compare two configs"},
+    ],
+})
+
 _start_time = time.time()
 
 
@@ -67,10 +105,17 @@ def _add_security_headers(response):
     response.headers.setdefault(
         "Permissions-Policy", "geolocation=(), microphone=(), camera=()"
     )
+    # Swagger UI (flasgger) serves its own bundled JS from the same origin and
+    # uses inline scripts for initialisation — relax script-src for those paths only.
+    _is_docs = request.path.startswith(("/api/docs", "/flasgger_static/", "/apispec"))
+    if _is_docs:
+        script_src = "'self' 'unsafe-inline' https://cdn.jsdelivr.net"
+    else:
+        script_src = f"'nonce-{nonce}' https://cdn.jsdelivr.net"
     response.headers.setdefault(
         "Content-Security-Policy",
         f"default-src 'self'; "
-        f"script-src 'nonce-{nonce}' https://cdn.jsdelivr.net; "
+        f"script-src {script_src}; "
         f"style-src 'self' 'unsafe-inline'; "
         f"img-src 'self' data:; "
         f"connect-src 'self'; "


### PR DESCRIPTION
## Summary

Phase 1 of the production-grade foundation roadmap is complete with this PR. Closes #43, #44, #45.

- **Auth event audit logging** — new `auth_events` SQLite table + `auth_audit.py` module captures every security-relevant event (logins, failures, lockouts, invalid API keys, user management, settings/license changes). Security Log sub-tab added to History UI (admin + auditor visible).
- **OpenAPI / Swagger docs** — `flasgger` added; Swagger UI live at `/api/docs` (public). Full YAML specs on all 5 `/api/v1` routes with request params, response shapes, and `X-API-Key` security scheme.
- **Production deployment guide** — `docs/deployment.md` covering Docker Compose + nginx (primary) and Caddy (alternative), env var reference, persistent volume guidance, upgrade procedure, and a hardening checklist.

## Test plan

- [ ] 234 existing tests pass (`pytest tests/ -v`)
- [ ] App starts clean (`CASHEL_DB=/tmp/test.db python3 -c "from cashel.web import app"`)
- [ ] `/api/docs` accessible without login, Swagger UI renders all 5 routes
- [ ] Login failure → Security Log shows `Login Failed` entry with IP
- [ ] Successful login → Security Log shows `Login` entry with role in details
- [ ] Logout → Security Log shows `Logout` with correct actor username
- [ ] Settings save → Security Log shows `Settings Changed` with keys_updated list
- [ ] Auditor role can view Security Log but Clear button is not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)