### PR TITLE
ci+chore: CI on staging branches, harden gitignore/dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,4 +34,24 @@ env/
 
 # Local env files
 .env
+.env.local
+.env.*.local
 *.env
+
+# Secrets and credentials (should always be mounted as volumes, never baked in)
+*.key
+*.pem
+*.p12
+*.pkcs12
+*.crt
+*.pfx
+secrets.*
+
+# Database files (runtime data — always use volumes)
+*.db
+*.sqlite
+*.sqlite3
+
+# Planning and ops docs
+PLAN.md
+CLAUDE.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   push:
-    branches: [main]
+    branches: [main, staging]
 
 jobs:
   validate:

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,29 @@ __pycache__/
 *.pyd
 .Python
 
-# License file
+# License files
 .fwaudit_license
+.cashel_license
+*.license
+
+# Secrets and credentials
+.env
+.env.local
+.env.*.local
+*.key
+*.pem
+*.p12
+*.pkcs12
+*.crt
+*.pfx
+secrets.*
+config.local.*
+settings.local.*
+
+# Database files (runtime data — never commit)
+*.db
+*.sqlite
+*.sqlite3
 
 # Virtual environments
 .venv/


### PR DESCRIPTION
## Summary

- **CI now runs on staging** — validate job triggers on every push to `staging` and on `pull_request` targeting `staging`. No more finding issues only at the staging → main merge.
- **Hardened `.gitignore`** — added `.env*`, `*.key`, `*.pem`, `*.p12`, `*.crt`, `*.pfx`, `secrets.*`, `*.db`, `*.sqlite`, `.cashel_license`, `*.license`.
- **Hardened `.dockerignore`** — same key/cert/secret patterns; also blocks `*.db`/`*.sqlite` (runtime volumes, never in image) and internal docs.

## Test plan

- [x] CI passed on staging push (validate + secret-scan ✓)
- [x] No currently-tracked files newly excluded by gitignore changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)