### PR TITLE
feat: critical severity level (#68)

### DIFF
--- a/src/cashel/audit_engine.py
+++ b/src/cashel/audit_engine.py
@@ -116,9 +116,9 @@ def _build_summary(findings):
 def _check_any_any(parse):
     return [
         _f(
-            "HIGH",
+            "CRITICAL",
             "exposure",
-            f"[HIGH] Overly permissive rule found: {r.text.strip()}",
+            f"[CRITICAL] Overly permissive rule found: {r.text.strip()}",
             "Restrict source and destination to specific IP ranges. "
             "Remove or scope down any/any permit rules to enforce least-privilege access.",
         )
@@ -176,9 +176,9 @@ def _check_redundant_rules(parse):
 def _check_telnet_asa(parse):
     return [
         _f(
-            "MEDIUM",
+            "CRITICAL",
             "protocol",
-            f"[MEDIUM] Telnet management access configured: {r.text.strip()}",
+            f"[CRITICAL] Telnet management access configured: {r.text.strip()}",
             "Disable Telnet management (no telnet ...) and enforce SSH. "
             "Telnet transmits all data including credentials in cleartext.",
         )

--- a/src/cashel/audit_engine.py
+++ b/src/cashel/audit_engine.py
@@ -45,19 +45,21 @@ def _sort_findings(findings: list) -> list:
         is_comp = any(
             x in msg for x in ("PCI-", "CIS-", "NIST-", "HIPAA-", "SOC2-", "STIG-")
         )
-        if "[HIGH]" in msg and not is_comp:
+        if "[CRITICAL]" in msg and not is_comp:
             return 0
-        if "[MEDIUM]" in msg and not is_comp:
+        if "[HIGH]" in msg and not is_comp:
             return 1
+        if "[MEDIUM]" in msg and not is_comp:
+            return 2
         if "STIG-CAT-I" in msg:
-            return 2
+            return 3
         if "HIGH" in msg and is_comp:
-            return 2
+            return 3
         if "STIG-CAT-II" in msg:
-            return 3
+            return 4
         if "MEDIUM" in msg and is_comp:
-            return 3
-        return 4
+            return 4
+        return 5
 
     return sorted(findings, key=priority)
 
@@ -67,6 +69,12 @@ def _build_summary(findings):
         return len([f for f in findings if tag in _finding_msg(f)])
 
     _comp_tags = ["PCI-", "CIS-", "NIST-", "HIPAA-", "SOC2-", "STIG-"]
+    critical = [
+        f
+        for f in findings
+        if "[CRITICAL]" in _finding_msg(f)
+        and not any(x in _finding_msg(f) for x in _comp_tags)
+    ]
     high = [
         f
         for f in findings
@@ -79,8 +87,9 @@ def _build_summary(findings):
         if "[MEDIUM]" in _finding_msg(f)
         and not any(x in _finding_msg(f) for x in _comp_tags)
     ]
-    score = max(0, 100 - len(high) * 10 - len(medium) * 3)
+    score = max(0, 100 - len(critical) * 20 - len(high) * 10 - len(medium) * 3)
     return {
+        "critical": len(critical),
         "high": len(high),
         "medium": len(medium),
         "pci_high": _count("PCI-HIGH"),

--- a/src/cashel/blueprints/api_v1.py
+++ b/src/cashel/blueprints/api_v1.py
@@ -96,6 +96,9 @@ def api_audit():
                 summary:
                   type: object
                   properties:
+                    critical:
+                      type: integer
+                      description: Count of CRITICAL-severity findings.
                     high:
                       type: integer
                     medium:

--- a/src/cashel/blueprints/audit.py
+++ b/src/cashel/blueprints/audit.py
@@ -100,43 +100,43 @@ _DEMO_COMPARISON_PAIRS = {
 # Pre-canned demo SSH audit result (Cisco ASA scenario).
 _DEMO_SSH_FINDINGS = [
     {
-        "severity": "critical",
+        "severity": "CRITICAL",
         "category": "exposure",
         "message": "[CRITICAL] Telnet enabled on inside interface — transmits credentials in plaintext",
         "remediation": "Disable Telnet with 'no telnet' and enforce SSH for all remote management access.",
     },
     {
-        "severity": "high",
+        "severity": "HIGH",
         "category": "protocol",
         "message": "[HIGH] SNMPv2 community string 'public' configured — no per-user auth, plaintext on wire",
         "remediation": "Migrate to SNMPv3 with authPriv. Remove all SNMPv2 community strings.",
     },
     {
-        "severity": "high",
+        "severity": "HIGH",
         "category": "exposure",
         "message": "[HIGH] ACL OUTSIDE_IN contains 'permit ip any any' — unrestricted inbound traffic",
         "remediation": "Replace with explicit permit rules scoped to required sources, destinations, and services. Ensure a deny-all terminator exists.",
     },
     {
-        "severity": "high",
+        "severity": "HIGH",
         "category": "exposure",
         "message": "[HIGH] ASDM HTTP server accessible from 0.0.0.0/0 on outside interface",
         "remediation": "Restrict HTTP server to management subnets only: 'http <mgmt-subnet> <mask> inside'. Remove the 0.0.0.0/0 outside entry.",
     },
     {
-        "severity": "medium",
+        "severity": "MEDIUM",
         "category": "hygiene",
         "message": "[MEDIUM] Duplicate ACL rule — 'permit tcp any host 172.16.0.10 eq 80' appears twice in OUTSIDE_IN",
         "remediation": "Remove the duplicate entry. Use 'show access-list' hit counts to identify and consolidate redundant rules.",
     },
     {
-        "severity": "medium",
+        "severity": "MEDIUM",
         "category": "hygiene",
         "message": "[MEDIUM] NTP not configured — log timestamps will be unreliable",
         "remediation": "Configure at least two NTP servers: 'ntp server <ip> prefer'. Ensure NTP traffic is permitted by the management ACL.",
     },
     {
-        "severity": "low",
+        "severity": "LOW",
         "category": "compliance",
         "message": "[LOW] No login banner configured — required by CIS and STIG for legal notice",
         "remediation": "Add 'banner login' or 'banner motd' with an authorised-use warning.",

--- a/src/cashel/export.py
+++ b/src/cashel/export.py
@@ -14,9 +14,12 @@ TOOL_INFO_URI = "https://github.com/Shamrock13/cashel"
 
 
 def _sarif_level(severity: str) -> str:
-    return {"HIGH": "error", "MEDIUM": "warning", "LOW": "note"}.get(
-        (severity or "").upper(), "warning"
-    )
+    return {
+        "CRITICAL": "error",
+        "HIGH": "error",
+        "MEDIUM": "warning",
+        "LOW": "note",
+    }.get((severity or "").upper(), "warning")
 
 
 def _parse_plain(finding) -> tuple[str, str, str, str]:

--- a/src/cashel/ftd.py
+++ b/src/cashel/ftd.py
@@ -114,9 +114,9 @@ def _check_ssl_inspection(parse):
 def _check_any_any(parse):
     return [
         _f(
-            "HIGH",
+            "CRITICAL",
             "exposure",
-            f"[HIGH] Overly permissive rule found: {r.text.strip()}",
+            f"[CRITICAL] Overly permissive rule found: {r.text.strip()}",
             "Restrict source and destination to specific IP ranges. "
             "Remove or scope down any/any permit rules to enforce least-privilege access.",
         )
@@ -155,9 +155,9 @@ def _check_deny_all(parse):
 def _check_telnet(parse):
     return [
         _f(
-            "MEDIUM",
+            "CRITICAL",
             "protocol",
-            f"[MEDIUM] Telnet management access configured: {r.text.strip()}",
+            f"[CRITICAL] Telnet management access configured: {r.text.strip()}",
             "Disable Telnet (no telnet ...) and enforce SSH for all management access. "
             "Telnet transmits credentials and session data in cleartext.",
         )

--- a/src/cashel/juniper.py
+++ b/src/cashel/juniper.py
@@ -241,9 +241,9 @@ def check_any_any_juniper(policies: list[dict]) -> list[dict]:
             label = f"{p['from_zone']}→{p['to_zone']} policy '{p['name']}'"
             findings.append(
                 _f(
-                    "HIGH",
+                    "CRITICAL",
                     "exposure",
-                    f"[HIGH] {label}: permits any source, any destination, any application.",
+                    f"[CRITICAL] {label}: permits any source, any destination, any application.",
                     f"Restrict source-address, destination-address, and application in policy '{p['name']}'. "
                     "Apply least-privilege — allow only the specific zones, addresses, and applications needed.",
                 )
@@ -280,11 +280,14 @@ def check_insecure_apps_juniper(policies: list[dict]) -> list[dict]:
         if not bad:
             continue
         label = f"{p['from_zone']}→{p['to_zone']} policy '{p['name']}'"
+        # Telnet is CRITICAL; other insecure apps are HIGH
+        has_telnet = any(a.lower() in ("telnet", "junos-telnet") for a in bad)
+        severity = "CRITICAL" if has_telnet else "HIGH"
         findings.append(
             _f(
-                "HIGH",
+                severity,
                 "protocol",
-                f"[HIGH] {label}: permits insecure application(s): {', '.join(bad)}.",
+                f"[{severity}] {label}: permits insecure application(s): {', '.join(bad)}.",
                 "Replace cleartext protocols with encrypted equivalents: "
                 "use SSH instead of Telnet, SFTP/SCP instead of FTP, and SNMPv3 instead of SNMP. "
                 f"Remove or restrict the application term in policy '{p['name']}'.",
@@ -341,9 +344,9 @@ def check_system_juniper(content: str) -> list[dict]:
     if has_telnet:
         findings.append(
             _f(
-                "HIGH",
+                "CRITICAL",
                 "management",
-                "[HIGH] Telnet management service is enabled.",
+                "[CRITICAL] Telnet management service is enabled.",
                 "Disable Telnet: 'delete system services telnet' (set style) or remove the "
                 "telnet stanza from 'system { services { ... } }'. Use SSH exclusively.",
             )

--- a/src/cashel/remediation.py
+++ b/src/cashel/remediation.py
@@ -257,7 +257,7 @@ _CATEGORY_ORDER = [
     "redundancy",
     "compliance",
 ]
-_SEVERITY_ORDER = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+_SEVERITY_ORDER = {"CRITICAL": -1, "HIGH": 0, "MEDIUM": 1, "LOW": 2}
 
 _CATEGORY_LABELS = {
     "exposure": "Access Control & Exposure",
@@ -661,9 +661,16 @@ def plan_to_pdf(plan: dict, output_path: str) -> str:
             _section_header(pdf, phase["phase"], bar_color)
 
             for step in phase["steps"]:
-                sev_color = _HIGH if step["severity"] == "HIGH" else _MEDIUM
+                if step["severity"] == "CRITICAL":
+                    sev_color = (153, 0, 0)
+                    bg = (255, 230, 230)
+                elif step["severity"] == "HIGH":
+                    sev_color = _HIGH
+                    bg = _HIGH_BG
+                else:
+                    sev_color = _MEDIUM
+                    bg = _MEDIUM_BG
                 effort_color = _EFFORT_COLORS.get(step["effort"], _MUTED)
-                bg = _HIGH_BG if step["severity"] == "HIGH" else _MEDIUM_BG
 
                 # Estimate row height
                 desc = step["description"]

--- a/src/cashel/static/style.css
+++ b/src/cashel/static/style.css
@@ -23,6 +23,7 @@ html { overflow-y: scroll; }
   --btn-secondary-text:#1A1A2E;
 
   --high:        #CC2200;
+  --critical:    #990000;
   --medium:      #996600;
   --compliance:  #1A55CC;
   --pass:        #1A8055;
@@ -30,6 +31,9 @@ html { overflow-y: scroll; }
   --finding-high-bg:        rgba(204,34,0,0.07);
   --finding-high-border:    #CC2200;
   --finding-high-text:      #AA1100;
+  --finding-critical-bg:        rgba(153,0,0,0.07);
+  --finding-critical-border:    #990000;
+  --finding-critical-text:      #660000;
   --finding-medium-bg:      rgba(153,102,0,0.07);
   --finding-medium-border:  #996600;
   --finding-medium-text:    #7A5200;
@@ -80,6 +84,7 @@ html { overflow-y: scroll; }
   --btn-secondary-text:#E8E8F0;
 
   --high:        #FF6868;
+  --critical:    #FF4444;
   --medium:      #FFAA00;
   --compliance:  #4488FF;
   --pass:        #44BB88;
@@ -87,6 +92,9 @@ html { overflow-y: scroll; }
   --finding-high-bg:        rgba(255,104,104,0.08);
   --finding-high-border:    #FF6868;
   --finding-high-text:      #FFAAAA;
+  --finding-critical-bg:        rgba(255,68,68,0.10);
+  --finding-critical-border:    #FF4444;
+  --finding-critical-text:      #FF9999;
   --finding-medium-bg:      rgba(255,170,0,0.07);
   --finding-medium-border:  #FFAA00;
   --finding-medium-text:    #FFCC66;
@@ -576,6 +584,7 @@ select:focus, input[type="text"]:focus {
 .summary-lbl { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 0.25rem; }
 
 .sev-high       { background: var(--finding-high-bg);    border: 1px solid var(--high);        color: var(--high); }
+.sev-critical   { background: var(--finding-critical-bg);  border: 1px solid var(--critical);       color: var(--critical); }
 .sev-medium     { background: var(--finding-medium-bg);  border: 1px solid var(--medium);      color: var(--medium); }
 .sev-total      { background: var(--sev-total-bg);        border: 1px solid var(--sev-total-border); color: var(--text); }
 .sev-compliance { background: var(--finding-comp-bg);     border: 1px solid var(--compliance);  color: var(--compliance); }
@@ -592,6 +601,7 @@ select:focus, input[type="text"]:focus {
 }
 
 .finding-high             { background: var(--finding-high-bg);    border-color: var(--finding-high-border);    color: var(--finding-high-text); }
+.finding-critical         { background: var(--finding-critical-bg);  border-color: var(--finding-critical-border);  color: var(--finding-critical-text); }
 .finding-medium           { background: var(--finding-medium-bg);  border-color: var(--finding-medium-border);  color: var(--finding-medium-text); }
 .finding-compliance-high  { background: var(--finding-comp-bg);    border-color: var(--finding-comp-border);    color: var(--finding-comp-text); }
 .finding-compliance-medium{ background: var(--finding-comp-bg);    border-color: var(--finding-comp-border);    color: var(--finding-comp-text); }
@@ -1690,6 +1700,7 @@ select:focus, input[type="text"]:focus {
   letter-spacing: 0.3px;
 }
 .rem-badge-high   { background: rgba(204,34,0,0.1); color: #CC2200; }
+.rem-badge-critical { background: rgba(153,0,0,0.1); color: #990000; }
 .rem-badge-medium { background: rgba(153,102,0,0.1); color: #996600; }
 .rem-badge-quick  { background: rgba(26,128,85,0.1); color: #1A8055; }
 .rem-badge-moderate { background: rgba(153,102,0,0.1); color: #996600; }

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -1541,6 +1541,7 @@
     if (!activeFilter) return allFindings;
     return allFindings.filter(f => {
       const cls = findingClass(f);
+      if (activeFilter === "critical")   return cls === "finding-critical";
       if (activeFilter === "high")       return cls === "finding-high";
       if (activeFilter === "medium")     return cls === "finding-medium";
       if (activeFilter === "compliance") return cls === "finding-compliance-high" || cls === "finding-compliance-medium";
@@ -2123,7 +2124,7 @@
     el.innerHTML = entries.map(e => {
       const ts     = e.timestamp ? new Date(e.timestamp).toLocaleString() : "—";
       const vendor = VENDOR_LABELS[e.vendor] || e.vendor;
-      const hi = e.summary?.high || 0, med = e.summary?.medium || 0, tot = e.summary?.total || 0;
+      const crit = e.summary?.critical || 0, hi = e.summary?.high || 0, med = e.summary?.medium || 0, tot = e.summary?.total || 0;
       const primaryName = e.tag ? escHtml(e.tag) + " <span style='font-weight:400;color:var(--text-muted)'>v" + (e.version || 1) + "</span>" : escHtml(e.filename);
       const secondaryMeta = e.tag ? escHtml(e.filename) + " &bull; " + escHtml(vendor) + " &bull; " + escHtml(ts) : escHtml(vendor) + " &bull; " + escHtml(ts);
       return `<div class="history-entry" data-id="${escHtml(e.id)}">
@@ -2137,6 +2138,7 @@
           </div>
         </div>
         <div class="history-entry-right">
+          <span class="history-badge sev-critical" title="Critical">${crit}</span>
           <span class="history-badge sev-high" title="High">${hi}</span>
           <span class="history-badge sev-medium" title="Medium">${med}</span>
           <span class="history-badge sev-total" title="Total">${tot}</span>
@@ -2271,6 +2273,7 @@
           <div class="compare-filename">${escHtml(ea.filename)}</div>
           <div class="compare-ts">${escHtml(tsA)}</div>
           <div class="compare-stats">
+            <span class="sev-critical history-badge">${ea.summary.critical || 0} Crit</span>
             <span class="sev-high history-badge">${ea.summary.high} High</span>
             <span class="sev-medium history-badge">${ea.summary.medium} Med</span>
           </div>
@@ -2281,6 +2284,7 @@
           <div class="compare-filename">${escHtml(eb.filename)}</div>
           <div class="compare-ts">${escHtml(tsB)}</div>
           <div class="compare-stats">
+            <span class="sev-critical history-badge">${eb.summary.critical || 0} Crit</span>
             <span class="sev-high history-badge">${eb.summary.high} High</span>
             <span class="sev-medium history-badge">${eb.summary.medium} Med</span>
           </div>
@@ -2444,9 +2448,10 @@
   // ══════════════════════════════════════════════════════════ HELPERS ══
   function buildSummaryHTML(s) {
     const items = [
-      { label: "High",   value: s.high,   cls: "sev-high",   filter: "high" },
-      { label: "Medium", value: s.medium, cls: "sev-medium", filter: "medium" },
-      { label: "Total",  value: s.total,  cls: "sev-total",  filter: "all" },
+      { label: "Critical", value: s.critical || 0, cls: "sev-critical", filter: "critical" },
+      { label: "High",     value: s.high,           cls: "sev-high",     filter: "high" },
+      { label: "Medium",   value: s.medium,         cls: "sev-medium",   filter: "medium" },
+      { label: "Total",    value: s.total,           cls: "sev-total",    filter: "all" },
     ];
     if (s.cis_high    || s.cis_medium)   { items.push({ label:"CIS High",    value:s.cis_high,    cls:"sev-compliance",filter:"compliance"}); items.push({ label:"CIS Med",     value:s.cis_medium,   cls:"sev-compliance",filter:"compliance"}); }
     if (s.stig_cat_i  || s.stig_cat_ii || s.stig_cat_iii) {
@@ -2474,6 +2479,7 @@
 
   function findingClass(f) {
     const msg = typeof f === "object" ? f.message : f;
+    if (msg.includes("[CRITICAL]") && !msg.match(/PCI-|CIS-|NIST-|HIPAA-|SOC2-|STIG-/)) return "finding-critical";
     if (msg.includes("[HIGH]")   && !msg.match(/PCI-|CIS-|NIST-|HIPAA-|SOC2-|STIG-/)) return "finding-high";
     if (msg.includes("[MEDIUM]") && !msg.match(/PCI-|CIS-|NIST-|HIPAA-|SOC2-|STIG-/)) return "finding-medium";
     if (msg.match(/PCI-HIGH|CIS-HIGH|NIST-HIGH|HIPAA-HIGH|SOC2-HIGH|STIG-CAT-I\]/))   return "finding-compliance-high";
@@ -2581,6 +2587,7 @@
           <span class="bulk-status-badge badge-ok">&#10003; OK</span>
         </div>
         <div class="bulk-summary-row">
+          <span class="history-badge sev-critical" title="Critical">${s.critical||0} C</span>
           <span class="history-badge sev-high" title="High">${s.high||0} H</span>
           <span class="history-badge sev-medium" title="Medium">${s.medium||0} M</span>
           <span class="history-badge sev-total" title="Total">${s.total||0} Total</span>
@@ -3532,8 +3539,9 @@
       "change-window": '<span class="rem-badge rem-badge-change">Change Window</span>',
     };
     const SEV_BADGES = {
-      "HIGH":   '<span class="rem-badge rem-badge-high">HIGH</span>',
-      "MEDIUM": '<span class="rem-badge rem-badge-medium">MEDIUM</span>',
+      "CRITICAL": '<span class="rem-badge rem-badge-critical">CRITICAL</span>',
+      "HIGH":     '<span class="rem-badge rem-badge-high">HIGH</span>',
+      "MEDIUM":   '<span class="rem-badge rem-badge-medium">MEDIUM</span>',
     };
 
     function escH(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }

--- a/tests/test_critical_severity.py
+++ b/tests/test_critical_severity.py
@@ -5,10 +5,22 @@ Run with:  python -m pytest tests/test_critical_severity.py -v
 
 import os
 import sys
+import tempfile
+from os import unlink as _os_unlink
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from cashel.audit_engine import _build_summary, _sort_findings
+from ciscoconfparse import CiscoConfParse
+from cashel.audit_engine import (
+    _build_summary,
+    _sort_findings,
+    _check_any_any,
+    _check_telnet_asa,
+)
+from cashel.ftd import (
+    _check_any_any as ftd_check_any_any,
+    _check_telnet as ftd_check_telnet,
+)
 
 
 def _f(severity, msg):
@@ -88,3 +100,47 @@ def test_sort_critical_before_high():
     assert "[CRITICAL]" in sorted_f[0]["message"]
     assert "[HIGH]" in sorted_f[1]["message"]
     assert "[MEDIUM]" in sorted_f[2]["message"]
+
+
+# ── Vendor parser severity promotions ─────────────────────────────────────────
+
+
+def _asa_parse(cfg_text: str):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cfg", delete=False) as fh:
+        fh.write(cfg_text)
+        path = fh.name
+    parse = CiscoConfParse(path, ignore_blank_lines=False)
+    _os_unlink(path)
+    return parse
+
+
+def test_asa_any_any_is_critical():
+    parse = _asa_parse("access-list OUTSIDE_IN permit ip any any\n")
+    findings = _check_any_any(parse)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "CRITICAL"
+    assert "[CRITICAL]" in findings[0]["message"]
+
+
+def test_asa_telnet_is_critical():
+    parse = _asa_parse("telnet 0.0.0.0 0.0.0.0 mgmt\n")
+    findings = _check_telnet_asa(parse)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "CRITICAL"
+    assert "[CRITICAL]" in findings[0]["message"]
+
+
+def test_ftd_any_any_is_critical():
+    parse = _asa_parse("access-list OUTSIDE_IN permit ip any any\n")
+    findings = ftd_check_any_any(parse)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "CRITICAL"
+    assert "[CRITICAL]" in findings[0]["message"]
+
+
+def test_ftd_telnet_is_critical():
+    parse = _asa_parse("telnet 0.0.0.0 0.0.0.0 mgmt\n")
+    findings = ftd_check_telnet(parse)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "CRITICAL"
+    assert "[CRITICAL]" in findings[0]["message"]

--- a/tests/test_critical_severity.py
+++ b/tests/test_critical_severity.py
@@ -1,0 +1,90 @@
+"""Tests for critical severity level in audit_engine.
+
+Run with:  python -m pytest tests/test_critical_severity.py -v
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from cashel.audit_engine import _build_summary, _sort_findings
+
+
+def _f(severity, msg):
+    return {
+        "severity": severity,
+        "category": "exposure",
+        "message": msg,
+        "remediation": "",
+    }
+
+
+# ── _build_summary ─────────────────────────────────────────────────────────────
+
+
+def test_summary_counts_critical():
+    findings = [
+        _f("CRITICAL", "[CRITICAL] permit any any found"),
+        _f("HIGH", "[HIGH] no deny-all"),
+        _f("MEDIUM", "[MEDIUM] no logging"),
+    ]
+    s = _build_summary(findings)
+    assert s["critical"] == 1
+    assert s["high"] == 1
+    assert s["medium"] == 1
+    assert s["total"] == 3
+
+
+def test_summary_critical_zero_when_absent():
+    findings = [_f("HIGH", "[HIGH] no deny-all")]
+    s = _build_summary(findings)
+    assert s["critical"] == 0
+    assert s["high"] == 1
+
+
+def test_summary_score_penalises_critical_more():
+    # One CRITICAL: 100 - 20 = 80
+    s_crit = _build_summary([_f("CRITICAL", "[CRITICAL] permit any any")])
+    assert s_crit["score"] == 80
+
+    # One HIGH: 100 - 10 = 90
+    s_high = _build_summary([_f("HIGH", "[HIGH] no deny-all")])
+    assert s_high["score"] == 90
+
+
+def test_summary_score_combined():
+    # 1 CRITICAL + 1 HIGH + 1 MEDIUM: 100 - 20 - 10 - 3 = 67
+    findings = [
+        _f("CRITICAL", "[CRITICAL] permit any any"),
+        _f("HIGH", "[HIGH] no deny-all"),
+        _f("MEDIUM", "[MEDIUM] no logging"),
+    ]
+    assert _build_summary(findings)["score"] == 67
+
+
+def test_summary_score_floor_zero():
+    findings = [_f("CRITICAL", f"[CRITICAL] finding {i}") for i in range(10)]
+    assert _build_summary(findings)["score"] == 0
+
+
+def test_summary_compliance_tags_not_counted_as_critical():
+    # A compliance finding tagged [PCI-CRITICAL] is not a raw critical
+    findings = [_f("HIGH", "[PCI-CRITICAL] some pci finding")]
+    s = _build_summary(findings)
+    assert s["critical"] == 0
+
+
+# ── _sort_findings ─────────────────────────────────────────────────────────────
+
+
+def test_sort_critical_before_high():
+    findings = [
+        _f("HIGH", "[HIGH] deny-all missing"),
+        _f("CRITICAL", "[CRITICAL] permit any any"),
+        _f("MEDIUM", "[MEDIUM] no logging"),
+    ]
+    sorted_f = _sort_findings(findings)
+    assert "[CRITICAL]" in sorted_f[0]["message"]
+    assert "[HIGH]" in sorted_f[1]["message"]
+    assert "[MEDIUM]" in sorted_f[2]["message"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -66,6 +66,28 @@ ENTRY_EMPTY = {
     "findings": [],
 }
 
+ENTRY_WITH_CRITICAL = {
+    "filename": "asa-lab.cfg",
+    "vendor": "asa",
+    "timestamp": "2026-03-21T00:00:00Z",
+    "tag": "lab-device",
+    "summary": {"critical": 1, "high": 1, "medium": 0, "low": 0, "total": 2},
+    "findings": [
+        {
+            "severity": "CRITICAL",
+            "category": "exposure",
+            "message": "[CRITICAL] permit any any found — remove immediately.",
+            "remediation": "no access-list OUTSIDE_IN permit ip any any",
+        },
+        {
+            "severity": "HIGH",
+            "category": "hygiene",
+            "message": "[HIGH] No explicit deny-all rule.",
+            "remediation": "access-list OUTSIDE_IN deny ip any any log",
+        },
+    ],
+}
+
 
 # ══════════════════════════════════════════════════════════ JSON TESTS ══
 
@@ -197,6 +219,23 @@ def test_sarif_empty_findings():
     out = json.loads(to_sarif(ENTRY_EMPTY))
     assert out["runs"][0]["results"] == []
     assert out["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+def test_sarif_critical_maps_to_error():
+    """CRITICAL findings must map to SARIF 'error' level."""
+    out = json.loads(to_sarif(ENTRY_WITH_CRITICAL))
+    results = out["runs"][0]["results"]
+    critical_results = [
+        r for r in results if "CRITICAL" in r.get("message", {}).get("text", "")
+    ]
+    assert len(critical_results) == 1
+    assert critical_results[0]["level"] == "error"
+
+
+def test_json_export_preserves_critical_severity():
+    out = json.loads(to_json(ENTRY_WITH_CRITICAL))
+    severities = [f["severity"] for f in out["findings"]]
+    assert "CRITICAL" in severities
 
 
 # ── standalone runner ─────────────────────────────────────────────────────────

--- a/tests/test_juniper.py
+++ b/tests/test_juniper.py
@@ -252,6 +252,8 @@ def test_system_detects_telnet():
     findings = check_system_juniper(SET_STYLE_RISKY)
     msgs = [f["message"] for f in findings]
     assert any("Telnet" in m for m in msgs)
+    telnet_findings = [f for f in findings if "Telnet" in f["message"]]
+    assert all(f["severity"] == "CRITICAL" for f in telnet_findings)
 
 
 def test_system_detects_snmp_community():

--- a/tests/test_juniper.py
+++ b/tests/test_juniper.py
@@ -198,7 +198,7 @@ def test_any_any_detects_violation():
     policies = _parse_set_style(SET_STYLE_RISKY)
     findings = check_any_any_juniper(policies)
     assert len(findings) >= 1
-    assert all(f["severity"] == "HIGH" for f in findings)
+    assert all(f["severity"] == "CRITICAL" for f in findings)
 
 
 def test_any_any_clean_config():
@@ -224,7 +224,7 @@ def test_insecure_apps_detects_telnet():
     policies = _parse_set_style(SET_STYLE_RISKY)
     findings = check_insecure_apps_juniper(policies)
     assert any("junos-telnet" in f["message"] for f in findings)
-    assert all(f["severity"] == "HIGH" for f in findings)
+    assert all(f["severity"] == "CRITICAL" for f in findings)
 
 
 def test_insecure_apps_clean():

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -161,6 +161,30 @@ def test_generate_plan_severity_ordering():
     assert len(medium_indices) > 0
 
 
+def test_generate_plan_critical_before_high():
+    """CRITICAL findings must appear before HIGH in the plan."""
+    findings = [
+        {
+            "severity": "HIGH",
+            "category": "exposure",
+            "message": "[HIGH] No deny-all rule.",
+            "remediation": "Add deny-all.",
+        },
+        {
+            "severity": "CRITICAL",
+            "category": "exposure",
+            "message": "[CRITICAL] permit any any found.",
+            "remediation": "Remove permit any any.",
+        },
+    ]
+    plan = generate_plan(findings, "asa")
+    all_steps = [step for phase in plan["phases"] for step in phase["steps"]]
+    severities = [s["severity"] for s in all_steps]
+    critical_idx = severities.index("CRITICAL")
+    high_idx = severities.index("HIGH")
+    assert critical_idx < high_idx
+
+
 def test_generate_plan_category_grouping():
     """Steps should be grouped by category into phases."""
     plan = generate_plan(SAMPLE_FINDINGS, "asa")


### PR DESCRIPTION
## Summary

Adds CRITICAL as a fourth severity level above HIGH, wired through all layers of the audit engine.

### Completed (All Tasks — Ready to Merge)

- **Task 1** — `audit_engine.py`: `_build_summary()` counts `[CRITICAL]` findings, score formula penalises them 2× (`-20` vs `-10` for HIGH), `_sort_findings()` places CRITICAL at priority 0
- **Task 2** — Vendor parsers: `permit any any` and Telnet management promoted to CRITICAL in ASA (`audit_engine.py`), FTD (`ftd.py`), and Juniper (`juniper.py`)
- **Task 3** — Export/Remediation: SARIF maps CRITICAL → `error`; `_SEVERITY_ORDER` gets `CRITICAL: -1`; PDF renders CRITICAL in deep crimson `(153,0,0)` / `(255,230,230)`
- **Task 4** — CSS: `--critical` custom properties (light + dark), `.sev-critical`, `.finding-critical`, `.rem-badge-critical`
- **Task 5** — UI (`templates/index.html`): `findingClass()` detection, `getFilteredFindings()` filter, `buildSummaryHTML()` critical stat box, `SEV_BADGES`, history/compare/bulk badges
- **Task 6** — API + demo data: `critical` added to Swagger schema; demo finding severity values uppercased to match production convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)