### PR TITLE
feat: Open PDF in new tab (#70) + demo sample report for marketing (#69)

### DIFF
--- a/src/cashel/_helpers.py
+++ b/src/cashel/_helpers.py
@@ -44,6 +44,7 @@ _AUTH_EXEMPT_ENDPOINTS = {
     "auth.setup_post",
     "health",
     "static",
+    "audit.demo_sample_report",
 }
 
 # Path prefixes that bypass auth (Swagger UI and spec JSON — public API docs)

--- a/src/cashel/blueprints/audit.py
+++ b/src/cashel/blueprints/audit.py
@@ -284,14 +284,19 @@ def demo_sample_report():
     os.makedirs(REPORTS_FOLDER, exist_ok=True)
     cached_path = os.path.join(REPORTS_FOLDER, "demo_sample_report.pdf")
     if not os.path.exists(cached_path):
-        generate_report(
-            _DEMO_SSH_FINDINGS,
-            "cisco_asa_demo.txt",
-            "asa",
-            compliance="cis",
-            output_path=cached_path,
-            summary=_DEMO_SSH_SUMMARY,
-        )
+        # NOTE: cached indefinitely — delete demo_sample_report.pdf manually
+        # if _DEMO_SSH_FINDINGS or _DEMO_SSH_SUMMARY change in a future release.
+        try:
+            generate_report(
+                _DEMO_SSH_FINDINGS,
+                "cisco_asa_demo.txt",
+                "asa",
+                compliance="cis",
+                output_path=cached_path,
+                summary=_DEMO_SSH_SUMMARY,
+            )
+        except Exception as exc:
+            return jsonify({"error": f"Could not generate sample report: {exc}"}), 500
     return send_file(
         cached_path,
         mimetype="application/pdf",

--- a/src/cashel/blueprints/audit.py
+++ b/src/cashel/blueprints/audit.py
@@ -273,6 +273,32 @@ def demo_ssh_audit():
     )
 
 
+@audit_bp.route("/demo/sample-report.pdf")
+def demo_sample_report():
+    """Serve a sample audit report PDF for marketing preview.
+
+    Public — no authentication required (matches other /demo/* routes).
+    Renders from pre-canned Cisco ASA findings; result is cached on disk
+    so repeat requests are fast (re-generated if the file is missing).
+    """
+    os.makedirs(REPORTS_FOLDER, exist_ok=True)
+    cached_path = os.path.join(REPORTS_FOLDER, "demo_sample_report.pdf")
+    if not os.path.exists(cached_path):
+        generate_report(
+            _DEMO_SSH_FINDINGS,
+            "cisco_asa_demo.txt",
+            "asa",
+            compliance="cis",
+            output_path=cached_path,
+            summary=_DEMO_SSH_SUMMARY,
+        )
+    return send_file(
+        cached_path,
+        mimetype="application/pdf",
+        as_attachment=False,
+    )
+
+
 @audit_bp.route("/demo/bulk-audit", methods=["POST"])
 def demo_bulk_audit():
     """Run all demo sample configs through the audit engine and return bulk results."""

--- a/src/cashel/blueprints/reports.py
+++ b/src/cashel/blueprints/reports.py
@@ -93,14 +93,17 @@ def remediation_plan_inline():
             },
         )
     elif fmt == "pdf":
+        inline = request.args.get("inline") == "1"
         report_name = f"remediation_{uuid.uuid4().hex[:8]}.pdf"
         report_path = os.path.join(REPORTS_FOLDER, report_name)
+        os.makedirs(REPORTS_FOLDER, exist_ok=True)
         plan_to_pdf(plan, report_path)
+        download_name = f"{(filename or 'audit').rsplit('.', 1)[0]}_remediation.pdf"
         return send_file(
             report_path,
             mimetype="application/pdf",
-            as_attachment=True,
-            download_name=f"{(filename or 'audit').rsplit('.', 1)[0]}_remediation.pdf",
+            as_attachment=not inline,
+            download_name=download_name,
         )
     else:
         return jsonify(

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -3651,8 +3651,20 @@
         if (!res.ok) throw new Error("PDF generation failed");
         const blob = await res.blob();
         const url = URL.createObjectURL(blob);
-        window.open(url, "_blank", "noopener");
-        setTimeout(() => URL.revokeObjectURL(url), 60000);
+        // window.open returns null when blocked by popup blocker (doesn't throw)
+        const win = window.open(url, "_blank", "noopener");
+        if (!win) {
+          URL.revokeObjectURL(url);
+          alert("Popup blocked — please allow popups for this site to open the PDF.");
+          return;
+        }
+        // Revoke after the PDF has had time to load; also revoke if open throws
+        try {
+          setTimeout(() => URL.revokeObjectURL(url), 60000);
+        } catch (_) {
+          URL.revokeObjectURL(url);
+          throw _;
+        }
       } catch (err) { alert("Could not open PDF: " + err.message); }
     });
 

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -21,8 +21,17 @@
   <div class="demo-banner" id="demoBanner" role="banner">
     <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true" style="width:16px;height:16px;flex-shrink:0"><circle cx="10" cy="10" r="8"/><path d="M10 7v3M10 13h.01"/></svg>
     <span><strong>Live Demo</strong> &mdash; Sample configs are processed in memory and never stored. No account required.</span>
+    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">&#128196; Sample Report</a>
     <a href="https://github.com/shamrock13/cashel" target="_blank" rel="noopener" class="demo-banner-link">Get Cashel &rarr;</a>
     <button class="demo-banner-close" id="demoBannerClose" aria-label="Dismiss">&times;</button>
+  </div>
+  {% endif %}
+
+  {% if not demo_mode and not current_user %}
+  <div class="demo-banner" style="background:var(--surface-alt,#f0f4ff);color:var(--text,#1a1a2e);border-bottom:1px solid var(--border,#d0d5ea);">
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true" style="width:16px;height:16px;flex-shrink:0"><path d="M4 4h12v12H4z"/><path d="M8 8h4M8 11h4M8 14h2"/></svg>
+    <span>See what a Cashel audit report looks like &mdash; no account needed.</span>
+    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">&#128196; View Sample Report &rarr;</a>
   </div>
   {% endif %}
 

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -3511,7 +3511,8 @@
         <h3 class="modal-title">Remediation Plan</h3>
         <div style="display:flex;gap:0.5rem;align-items:center;">
           {% if not demo_mode %}
-          <button class="btn-secondary btn-sm" id="remPlanDownloadPdf" title="Download PDF">PDF</button>
+          <button class="btn-secondary btn-sm" id="remPlanOpenPdf" title="Open as PDF in new tab">&#x2197; Open PDF</button>
+          <button class="btn-secondary btn-sm" id="remPlanDownloadPdf" title="Download PDF">&#8681; PDF</button>
           <button class="btn-secondary btn-sm" id="remPlanDownloadMd" title="Download Markdown">MD</button>
           {% endif %}
           <button class="modal-close" id="remediationModalClose" aria-label="Close">&times;</button>
@@ -3637,6 +3638,24 @@
 
     /* Download helpers (non-demo only) */
     {% if not demo_mode %}
+    document.getElementById("remPlanOpenPdf")?.addEventListener("click", async () => {
+      if (!lastPlanPayload) return;
+      try {
+        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+                       || document.querySelector('input[name="csrf_token"]')?.value || '';
+        const res = await fetch("/remediation-plan?fmt=pdf&inline=1", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-CSRFToken": csrfToken },
+          body: JSON.stringify(lastPlanPayload),
+        });
+        if (!res.ok) throw new Error("PDF generation failed");
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        window.open(url, "_blank", "noopener");
+        setTimeout(() => URL.revokeObjectURL(url), 60000);
+      } catch (err) { alert("Could not open PDF: " + err.message); }
+    });
+
     document.getElementById("remPlanDownloadPdf")?.addEventListener("click", async () => {
       if (!lastPlanPayload) return;
       try {

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,101 @@
+"""Route tests for /remediation-plan and /demo/sample-report.pdf."""
+import os
+import sys
+import tempfile
+import unittest
+
+# Point the DB at a writable temp location before importing the app
+_TEST_DB_DIR = tempfile.mkdtemp()
+os.environ.setdefault("CASHEL_DB", os.path.join(_TEST_DB_DIR, "test_cashel.db"))
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import cashel.web as web_mod
+
+
+def _make_client():
+    app = web_mod.app
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    return app.test_client()
+
+
+def _ensure_user_exists():
+    """Create a test user so has_users() returns True and the auth gate passes."""
+    from cashel import user_store as us
+    from cashel.user_store import UserValidationError
+
+    try:
+        us.create_user("testadmin", "TestPass123!", "admin")
+    except UserValidationError:
+        pass  # user already exists — fine
+
+
+SAMPLE_PAYLOAD = {
+    "findings": [
+        {
+            "severity": "HIGH",
+            "category": "exposure",
+            "message": "[HIGH] permit ip any any",
+            "remediation": "Replace with specific rules.",
+        }
+    ],
+    "vendor": "asa",
+    "filename": "test.txt",
+}
+
+
+class TestRemediationPdfInline(unittest.TestCase):
+    def setUp(self):
+        import cashel.settings as settings_mod
+
+        # Use an isolated temp settings file with auth disabled so routes are
+        # reachable without a login session.
+        self.tmp_dir = tempfile.mkdtemp()
+        self._tmp_settings = os.path.join(self.tmp_dir, "settings.json")
+        self._orig_settings_file = settings_mod.SETTINGS_FILE
+        settings_mod.SETTINGS_FILE = self._tmp_settings
+
+        self._orig_folder = os.environ.get("REPORTS_FOLDER")
+        os.environ["REPORTS_FOLDER"] = self.tmp_dir
+        import cashel.blueprints.reports as r
+        r.REPORTS_FOLDER = self.tmp_dir
+
+        _ensure_user_exists()
+        self.client = _make_client()
+
+    def tearDown(self):
+        import cashel.settings as settings_mod
+        settings_mod.SETTINGS_FILE = self._orig_settings_file
+
+        if self._orig_folder is None:
+            os.environ.pop("REPORTS_FOLDER", None)
+        else:
+            os.environ["REPORTS_FOLDER"] = self._orig_folder
+
+    def test_pdf_inline_returns_pdf_content_type(self):
+        resp = self.client.post(
+            "/remediation-plan?fmt=pdf&inline=1",
+            json=SAMPLE_PAYLOAD,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("application/pdf", resp.content_type)
+
+    def test_pdf_inline_does_not_set_attachment_disposition(self):
+        resp = self.client.post(
+            "/remediation-plan?fmt=pdf&inline=1",
+            json=SAMPLE_PAYLOAD,
+        )
+        cd = resp.headers.get("Content-Disposition", "")
+        self.assertNotIn("attachment", cd)
+
+    def test_pdf_attachment_still_works(self):
+        """Default (no inline=1) must remain attachment for backward compat."""
+        resp = self.client.post(
+            "/remediation-plan?fmt=pdf",
+            json=SAMPLE_PAYLOAD,
+        )
+        self.assertEqual(resp.status_code, 200)
+        cd = resp.headers.get("Content-Disposition", "")
+        self.assertIn("attachment", cd)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -10,10 +10,8 @@ os.environ.setdefault("CASHEL_DB", os.path.join(_TEST_DB_DIR, "test_cashel.db"))
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-import cashel.web as web_mod
-
-
 def _make_client():
+    import cashel.web as web_mod
     app = web_mod.app
     app.config["TESTING"] = True
     app.config["WTF_CSRF_ENABLED"] = False
@@ -62,8 +60,8 @@ class TestRemediationPdfInline(unittest.TestCase):
         import cashel.blueprints.reports as r
         r.REPORTS_FOLDER = self.tmp_dir
 
-        _ensure_user_exists()
         self.client = _make_client()
+        _ensure_user_exists()
 
     def tearDown(self):
         import cashel.settings as settings_mod
@@ -73,6 +71,8 @@ class TestRemediationPdfInline(unittest.TestCase):
             os.environ.pop("REPORTS_FOLDER", None)
         else:
             os.environ["REPORTS_FOLDER"] = self._orig_folder
+        import cashel.blueprints.reports as r
+        r.REPORTS_FOLDER = self._orig_folder if self._orig_folder is not None else "/tmp/cashel_reports"
 
     def test_pdf_inline_returns_pdf_content_type(self):
         resp = self.client.post(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -4,10 +4,6 @@ import sys
 import tempfile
 import unittest
 
-# Point the DB at a writable temp location before importing the app
-_TEST_DB_DIR = tempfile.mkdtemp()
-os.environ.setdefault("CASHEL_DB", os.path.join(_TEST_DB_DIR, "test_cashel.db"))
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 def _make_client():
@@ -46,7 +42,17 @@ SAMPLE_PAYLOAD = {
 
 class TestRemediationPdfInline(unittest.TestCase):
     def setUp(self):
+        import cashel.db as db_mod
         import cashel.settings as settings_mod
+
+        # Isolated temp DB so tests pass regardless of execution order.
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            self._tmp_db_path = f.name
+        self._orig_db_path = db_mod.DB_PATH
+        self._orig_db_conn = getattr(db_mod._local, "conn", None)
+        db_mod.DB_PATH = self._tmp_db_path
+        db_mod._local.conn = None
+        db_mod.init_db()
 
         # Use an isolated temp settings file with auth disabled so routes are
         # reachable without a login session.
@@ -64,7 +70,19 @@ class TestRemediationPdfInline(unittest.TestCase):
         _ensure_user_exists()
 
     def tearDown(self):
+        import cashel.db as db_mod
         import cashel.settings as settings_mod
+
+        conn = getattr(db_mod._local, "conn", None)
+        if conn:
+            conn.close()
+        db_mod.DB_PATH = self._orig_db_path
+        db_mod._local.conn = self._orig_db_conn
+        try:
+            os.unlink(self._tmp_db_path)
+        except OSError:
+            pass
+
         settings_mod.SETTINGS_FILE = self._orig_settings_file
 
         if self._orig_folder is None:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -99,3 +99,38 @@ class TestRemediationPdfInline(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         cd = resp.headers.get("Content-Disposition", "")
         self.assertIn("attachment", cd)
+
+
+class TestDemoSampleReport(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self._orig_folder = os.environ.get("REPORTS_FOLDER")
+        os.environ["REPORTS_FOLDER"] = self.tmp_dir
+        import cashel.blueprints.audit as a
+        a.REPORTS_FOLDER = self.tmp_dir
+        self.client = _make_client()
+
+    def tearDown(self):
+        if self._orig_folder is None:
+            os.environ.pop("REPORTS_FOLDER", None)
+        else:
+            os.environ["REPORTS_FOLDER"] = self._orig_folder
+        import cashel.blueprints.audit as a
+        a.REPORTS_FOLDER = self._orig_folder if self._orig_folder is not None else "/tmp/cashel_reports"
+
+    def test_sample_report_returns_200(self):
+        resp = self.client.get("/demo/sample-report.pdf")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_sample_report_content_type_is_pdf(self):
+        resp = self.client.get("/demo/sample-report.pdf")
+        self.assertIn("application/pdf", resp.content_type)
+
+    def test_sample_report_is_inline_not_attachment(self):
+        resp = self.client.get("/demo/sample-report.pdf")
+        cd = resp.headers.get("Content-Disposition", "")
+        self.assertNotIn("attachment", cd)
+
+    def test_sample_report_returns_non_empty_pdf(self):
+        resp = self.client.get("/demo/sample-report.pdf")
+        self.assertTrue(resp.data[:4] == b"%PDF")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,4 +1,5 @@
 """Route tests for /remediation-plan and /demo/sample-report.pdf."""
+
 import os
 import sys
 import tempfile
@@ -6,8 +7,10 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+
 def _make_client():
     import cashel.web as web_mod
+
     app = web_mod.app
     app.config["TESTING"] = True
     app.config["WTF_CSRF_ENABLED"] = False
@@ -64,6 +67,7 @@ class TestRemediationPdfInline(unittest.TestCase):
         self._orig_folder = os.environ.get("REPORTS_FOLDER")
         os.environ["REPORTS_FOLDER"] = self.tmp_dir
         import cashel.blueprints.reports as r
+
         r.REPORTS_FOLDER = self.tmp_dir
 
         self.client = _make_client()
@@ -90,7 +94,12 @@ class TestRemediationPdfInline(unittest.TestCase):
         else:
             os.environ["REPORTS_FOLDER"] = self._orig_folder
         import cashel.blueprints.reports as r
-        r.REPORTS_FOLDER = self._orig_folder if self._orig_folder is not None else "/tmp/cashel_reports"
+
+        r.REPORTS_FOLDER = (
+            self._orig_folder
+            if self._orig_folder is not None
+            else "/tmp/cashel_reports"
+        )
 
     def test_pdf_inline_returns_pdf_content_type(self):
         resp = self.client.post(
@@ -125,6 +134,7 @@ class TestDemoSampleReport(unittest.TestCase):
         self._orig_folder = os.environ.get("REPORTS_FOLDER")
         os.environ["REPORTS_FOLDER"] = self.tmp_dir
         import cashel.blueprints.audit as a
+
         a.REPORTS_FOLDER = self.tmp_dir
         self.client = _make_client()
 
@@ -134,7 +144,12 @@ class TestDemoSampleReport(unittest.TestCase):
         else:
             os.environ["REPORTS_FOLDER"] = self._orig_folder
         import cashel.blueprints.audit as a
-        a.REPORTS_FOLDER = self._orig_folder if self._orig_folder is not None else "/tmp/cashel_reports"
+
+        a.REPORTS_FOLDER = (
+            self._orig_folder
+            if self._orig_folder is not None
+            else "/tmp/cashel_reports"
+        )
 
     def test_sample_report_returns_200(self):
         resp = self.client.get("/demo/sample-report.pdf")


### PR DESCRIPTION
## Summary

- **#70** — Adds an "↗ Open PDF" button to the remediation plan modal that opens the plan inline in a new browser tab (vs. downloading). Backend: `POST /remediation-plan?fmt=pdf&inline=1` returns `Content-Disposition: inline`. Handles popup-blocked case gracefully with user feedback.
- **#69** — Adds a public `GET /demo/sample-report.pdf` route that renders a polished Cisco ASA audit report from pre-canned demo findings — no login required. Linked from the demo banner and a soft CTA bar for logged-out visitors.

## Test Plan
- [ ] Remediation modal "↗ Open PDF" button opens PDF in browser tab (not a download)
- [ ] "PDF" download button still works as before (backward compat)
- [ ] `/demo/sample-report.pdf` opens in new tab without login
- [ ] "Sample Report" link visible in demo banner (demo mode)
- [ ] Soft CTA bar visible when logged out (non-demo)
- [ ] CTA bar hidden when logged in
- [ ] 273 tests passing, ruff clean

Closes #70
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)