### PR TITLE
Align docs with product direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 *.crt
 *.pfx
 secrets.*
+!docs/secrets.md
 config.local.*
 settings.local.*
 

--- a/README.md
+++ b/README.md
@@ -2,177 +2,260 @@
 
 ![CI](https://github.com/Shamrock13/cashel/actions/workflows/ci.yml/badge.svg)
 
-**Cashel** is a self-hosted firewall configuration auditing and remediation tool built for network security engineers, MSPs, and security teams. Upload firewall configs, audit live devices over SSH, schedule recurring checks, compare configuration changes, and generate client-ready reports, remediation plans, and export bundles.
+**Cashel** is a self-hosted firewall audit and remediation platform for network engineers, MSPs, and security teams. It audits uploaded firewall configurations and live SSH pulls, preserves evidence for each finding where the parser supports it, and produces remediation-oriented reports and exports that can be reviewed, repeated, and defended.
 
-Cashel's current direction is focused on **trusted, evidence-backed findings** rather than adding more vendor breadth. The app now supports a normalized finding model that preserves legacy UI/API compatibility while adding fields such as stable finding IDs, evidence, affected objects, confidence, verification guidance, rollback notes, compliance references, and suggested commands where available.
+The product direction is depth over breadth: trusted, evidence-backed, reproducible findings for the platforms engineers operate every day. Near-term work should prioritize Fortinet, Palo Alto Networks, and Cisco ASA/FTD correctness, SSO readiness, security hardening, operational clarity, and policy-as-code workflows before adding more vendors.
 
-**Try the live demo:** [demo.cashel.app](https://demo.cashel.app)
-
-[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/Shamrock13)
-[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20Cashel-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/shamrock13)
+**Demo:** [demo.cashel.app](https://demo.cashel.app)
 
 ---
 
-## Current Application State
+## Current State
 
-Cashel currently includes:
+Implemented today:
 
-- Multi-vendor firewall and cloud security-group auditing
 - Web UI and CLI audit workflows
 - Single-file and bulk config audits
 - Live SSH audits for supported network firewall platforms
-- Scheduled SSH audits with alerting
-- Audit history, activity logging, score trends, and saved report views
-- Rule diffing between two configs of the same vendor
-- Severity scoring with CRITICAL / HIGH / MEDIUM / LOW findings
-- Compliance checks behind a license key
-- Export formats: PDF, JSON, CSV, SARIF, and evidence bundles
-- Structured remediation plans with Markdown and PDF output
-- Vendor-specific suggested commands where safe and practical
-- Normalized finding fields for evidence-backed reporting and future policy-as-code workflows
+- Scheduled SSH audits with saved encrypted credentials
+- Audit history, activity logging, score trends, archived comparisons, and saved report views
+- Modern audit, remediation, and evidence-bundle PDFs rendered with Playwright/Chromium
+- JSON, CSV, SARIF, PDF, and evidence-bundle exports
+- Structured remediation output that prefers enriched finding fields before falling back to legacy messages
+- Normalized finding dictionaries for many newer checks, while preserving legacy string finding compatibility
+- ASA object/object-group expansion and enriched ASA findings
+- Fortinet, Palo Alto, Juniper, and pfSense parser improvements with varying maturity by check family
+- CI validation for Ruff, formatting, mypy, pytest, dependency sync, XML parser safety, Docker build, and secret scanning
 
-### Evidence-backed finding coverage
+Partially implemented:
 
-The normalized finding model is in place, but not every vendor/check has been fully migrated yet.
+- Stable finding IDs across all vendors and checks
+- Evidence-backed findings for every vendor-specific rule
+- Scope-aware shadow analysis across nested groups, services, ports, zones, NAT context, and vendor-specific abstractions
+- Data-driven compliance/control mappings
+- Policy-as-code and CI gate outputs
+- MSP-grade reporting workflows
 
-Currently enriched:
+Planned:
 
-- Cisco ASA core checks:
-  - overly permissive any-any ACL rules
-  - permit rules missing logging
-  - missing explicit deny-all logging
-  - duplicate/redundant ACL entries
-  - Telnet management exposure
-  - unrestricted ICMP any-any rules
-- Rule shadowing findings for:
-  - Cisco ASA / FTD
-  - Palo Alto Networks
-  - Fortinet FortiGate
-  - pfSense
-  - Azure NSG
-  - Juniper SRX
-- Remediation plans now prefer structured finding fields such as `title`, `id`, `evidence`, `verification`, `rollback`, `affected_object`, and `suggested_commands` before falling back to legacy message parsing.
-- JSON exports preserve enriched finding fields.
-- CSV exports include `id`, `title`, `evidence`, and remediation columns.
-- SARIF exports prefer stable finding IDs as rule IDs when available.
+- OIDC SSO as a first-class authentication mode
+- License-gating removal or replacement with a clearer non-paid feature model
+- NormalizedRule and NormalizedFinding model completion
+- Deeper Fortinet, Palo Alto, and Cisco ASA/FTD object expansion
+- Bounded background execution for large PDFs, bulk audits, and scheduled audit queues
 
-Still being migrated:
+Deprecated / under review:
 
-- Full structured finding coverage for Fortinet, Palo Alto, Juniper, pfSense, iptables/nftables, AWS, Azure, and GCP vendor-specific checks
-- Deeper object expansion for Fortinet, Palo Alto, and ASA/FTD
-- Data-driven compliance-control mappings
-- Policy-as-code gates for CI/CD
+- The current license-gated compliance implementation
+- Legacy paid compliance messaging
+- Treating all supported vendors as equal maturity
 
 ---
 
-## Supported Vendors
+## Supported Vendor Maturity
 
-Cashel supports on-prem firewall configs, Linux host firewall configs, and cloud security-group style policies.
+Cashel intentionally does not claim equal depth for every parser. Current maturity should be read as audit maturity, not a promise that every check is fully normalized or evidence-backed.
 
-> **Cisco note:** Cashel exposes Cisco ASA and FTD under a single Cisco option in the UI. The platform can auto-detect ASA vs. FTD from config content and apply the relevant checks.
-
-| Vendor | Config Format | Live SSH | Notes |
-|---|---|---:|---|
-| AWS Security Groups | JSON | — | Audit only; no rule-order shadowing |
-| Azure NSG | JSON | — | Includes priority-based shadow checks |
-| Cisco ASA / FTD | Text | ✓ | ASA audit findings are evidence-backed and normalized |
-| Fortinet FortiGate | Text | ✓ | Enriched findings with address/service object expansion and shadow detection |
-| GCP VPC Firewall | JSON | — | Audit only |
-| iptables / nftables | Text | ✓ | Linux host firewall checks |
-| Juniper SRX | Text | ✓ | Enriched findings with address-book/application-set expansion and zone-pair shadow detection |
-| Palo Alto Networks | XML | ✓ | Enriched findings with address/service/application expansion and shadow detection |
-| pfSense | XML | ✓ | Enriched findings with alias expansion and interface-aware shadow detection |
-
-Full list of vendor-specific checks: [docs/checks.md](docs/checks.md)
-
----
-
-## Features
-
-### Audit Engine
-
-- **Severity model** — CRITICAL / HIGH / MEDIUM / LOW findings sorted and color-coded by risk
-- **Security scoring** — 0–100 per audit: `100 − (CRITICAL×20) − (HIGH×10) − (MEDIUM×3)`
-- **Auto vendor detection** — identifies supported vendors from config content
-- **Hostname extraction** — device hostname can auto-populate the Device Tag field when detectable
-- **Category badges** — findings grouped by exposure, protocol, logging, hygiene, redundancy, and compliance
-- **Normalized findings** — additive structured fields for evidence, stable IDs, affected objects, verification, rollback, and suggested commands
-- **Legacy compatibility** — older string/dict findings still render and export
-
-### Audit Modes
-
-- **Single file** — upload one config and receive score, findings, remediation guidance, and exports
-- **Bulk** — upload multiple configs and audit each independently
-- **Live SSH** — connect to SSH-capable devices and audit running configs without storing one-time credentials
-- **Scheduled** — recurring SSH audits with saved history and optional alerting
-
-### Reports and Exports
-
-- **Modern PDF reports** — HTML/CSS-rendered audit reports using Playwright/Chromium
-- **Remediation reports** — grouped remediation steps with evidence, guidance, verification, rollback, and suggested commands when available
-- **Evidence bundles** — ZIP package containing report artifacts such as PDF, JSON, CSV, SARIF, and cover material
-- **JSON** — preserves full enriched finding dictionaries
-- **CSV** — spreadsheet-friendly export with stable IDs, vendor, title, evidence, affected object, rule name, confidence, and remediation columns
-- **SARIF** — security tooling integration using stable finding IDs where present
-- **REST API** — pipeline-friendly audit endpoint returning JSON findings
-
-### History and Trends
-
-- **Audit History** — saved audits with vendor/date/tag filtering and search
-- **Score Trends** — score-over-time visualization by device/vendor/tag
-- **Archived comparisons** — compare two saved audits to identify resolved, new, and changed findings
-- **Device tags** — track repeated audits for named devices
-- **Activity Log** — records audits, SSH attempts, diffs, scheduled runs, and failures
-
-### Rule Quality Analysis
-
-- **Shadow detection** — flags rules that cannot match because earlier rules already cover the traffic scope
-- **Duplicate detection** — identifies duplicate rules that add no policy value
-- **Current limitation** — shadow logic is useful but not yet fully scope-aware across nested objects, CIDRs, service groups, NAT context, and all vendor-specific abstractions
-
-### Alerts and Integrations
-
-- Slack webhook
-- Microsoft Teams webhook
-- Email / SMTP
-- Syslog forwarding over UDP/TCP
-- Generic outbound webhooks with HMAC signing and SSRF protections
-
-### Platform and Security
-
-- Docker Compose deployment
-- Flask web UI and Typer CLI
-- SQLite persistence for audits, schedules, users, auth events, alert state, and integrations
-- RBAC roles for admin/auditor/viewer style access patterns
-- Configurable SSH host-key policy: Warn, Strict, or Auto-add
-- HTTP security headers
-- XML parsing via `defusedxml`
-- CI checks for Ruff, format, mypy, tests, XML parser safety, dependency sync, and secret scanning
-
----
-
-## Paid Features
-
-Compliance checks require a license key and map audit findings to control references.
-
-| Framework | Coverage | Vendors |
+| Maturity | Vendors | Current reality |
 |---|---|---|
-| CIS Benchmark | HIGH / MEDIUM | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
-| DISA STIG | CAT-I / CAT-II / CAT-III | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
-| HIPAA Security Rule | HIGH / MEDIUM | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
-| NIST SP 800-41 | HIGH / MEDIUM | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
-| PCI-DSS | HIGH / MEDIUM | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
-| SOC2 | HIGH / MEDIUM | Cisco ASA/FTD, Fortinet, Juniper, Palo Alto, pfSense |
+| Mature / enriched | Cisco ASA / FTD, Fortinet FortiGate, Palo Alto Networks | Primary investment area. These have the strongest evidence-backed finding and object-expansion direction, with ASA currently the most normalized. |
+| Partial / legacy-compatible | Juniper SRX, pfSense, iptables / nftables, Azure NSG | Useful checks exist, and legacy outputs are preserved. Some findings are enriched, but coverage is not yet uniformly normalized. |
+| Experimental / basic audit only | AWS Security Groups, GCP VPC Firewall | Basic static audit coverage. These are not the near-term depth priority. |
 
-> Purchase a license at [Gumroad](https://shamrock13.gumroad.com/l/cashel)
+> Cisco note: Cashel exposes Cisco ASA and FTD under a single Cisco option in the UI. The platform can auto-detect ASA vs. FTD from config content and apply relevant checks.
+
+Full list of current checks: [docs/checks.md](docs/checks.md)
+
+---
+
+## Known Limitations
+
+- Findings are not yet normalized everywhere. Legacy string findings remain supported and may appear in API/UI/export flows.
+- Shadow detection is useful but not fully scope-aware across every vendor abstraction, nested object group, service group, NAT rule, zone context, and CIDR interaction.
+- Compliance checks currently remain license-gated in code for some workflows. This behavior is under review and should not be treated as the long-term product model.
+- SSO/OIDC is documented as the target model but is not implemented yet.
+- SQLite is appropriate for lightweight self-hosted deployments, but it is not a horizontally scalable database.
+- Multi-worker deployments can duplicate scheduler execution unless external locking or a single scheduler process is used.
+- PDF generation can be CPU and memory intensive because it starts Chromium.
+- Bulk audits run in request/response paths today and should be bounded for large deployments.
+- Uploaded configs, generated reports, evidence bundles, and scheduled SSH credentials are sensitive and must be protected like production network documentation.
+- Demo mode is for public/demo use only and should not be treated as a secure production mode.
+
+---
+
+## Roadmap Priority
+
+1. Product truth / docs cleanup
+2. License decision/removal
+3. SSO/OIDC model
+4. Security hardening docs
+5. Performance/scaling guardrails
+6. NormalizedRule / NormalizedFinding model completion
+7. Stable finding IDs everywhere
+8. Evidence-backed vendor migration
+9. Scope-aware analysis
+10. Fortinet/Palo Alto/ASA depth
+11. Policy-as-code / CI gates
+12. MSP-grade reporting
+
+Cashel should avoid adding new vendors until the top vendor parsers produce consistently evidence-backed, reproducible results.
+
+See [docs/product-contract.md](docs/product-contract.md) for the status matrix and product contract.
+
+---
+
+## Authentication and SSO
+
+Current behavior:
+
+- Local users and API keys are implemented.
+- First-run setup creates a local admin.
+- Local auth can be disabled in settings for simple self-hosted use.
+- RBAC-style roles exist for admin, auditor, and viewer access patterns.
+
+Target direction:
+
+- Local auth should become the fallback/bootstrap mode.
+- OIDC should be the first SSO implementation.
+- SAML is a future roadmap item, not the first SSO target.
+- Supported OIDC deployments should include Microsoft Entra ID, Google Workspace, Okta, Authentik, and Keycloak.
+- Role mapping should derive Cashel roles from IdP claims/groups: `admin`, `auditor`, and `viewer`.
+
+Planned OIDC environment design:
+
+```bash
+CASHEL_AUTH_MODE=local|oidc
+CASHEL_OIDC_ISSUER=https://idp.example.com/
+CASHEL_OIDC_CLIENT_ID=cashel
+CASHEL_OIDC_CLIENT_SECRET=replace-me
+CASHEL_OIDC_REDIRECT_URI=https://cashel.example.com/auth/oidc/callback
+CASHEL_OIDC_ALLOWED_DOMAINS=example.com,example.org
+CASHEL_OIDC_ADMIN_GROUPS=NetSec Admins,Cashel Admins
+CASHEL_OIDC_AUDITOR_GROUPS=Network Engineers,MSP Auditors
+CASHEL_OIDC_VIEWER_GROUPS=Security Viewers
+```
+
+Deployment requirements for OIDC:
+
+- Serve Cashel behind HTTPS.
+- Set `CASHEL_SECURE_COOKIES=true`.
+- Configure the IdP callback URL exactly, including scheme and path.
+- Preserve `Host`, `X-Forwarded-Proto`, and client IP headers at the reverse proxy.
+- Keep local bootstrap/fallback access documented and restricted.
+- Store OIDC client secrets outside the repo and outside image layers.
+
+More detail: [docs/security-model.md](docs/security-model.md) and [docs/deployment-hardening.md](docs/deployment-hardening.md).
+
+---
+
+## Security Model
+
+Cashel handles sensitive network data:
+
+- Uploaded firewall configs
+- Live SSH connection details
+- Scheduled SSH credentials
+- Audit findings that reveal topology and control weaknesses
+- Generated PDFs, evidence bundles, CSV, JSON, and SARIF exports
+- Webhook/syslog destinations and secrets
+
+Minimum production requirements:
+
+- Set `CASHEL_SECRET` to a strong random value.
+- Set and persist `CASHEL_KEY_FILE`; do not regenerate it after encrypting secrets.
+- Put SQLite, reports, uploads, and key material on persistent storage.
+- Serve behind a TLS-terminating reverse proxy.
+- Enable secure cookies when served over HTTPS.
+- Limit upload sizes and report retention.
+- Review webhook allowlists and outbound egress policy.
+- Back up SQLite and key material together.
+
+Security docs:
+
+- [Security model](docs/security-model.md)
+- [Deployment hardening](docs/deployment-hardening.md)
+- [Secrets](docs/secrets.md)
+
+---
+
+## Performance and Scaling Notes
+
+Cashel is currently best suited to lightweight self-hosted deployments, MSP engineer workbenches, and small team installations.
+
+Operational considerations:
+
+- PDF generation is CPU/memory heavy because it uses Chromium.
+- Bulk audits should be bounded by upload count, file size, and request timeout.
+- Scope-aware shadow analysis can become expensive without caching/memoization.
+- Scheduled SSH audits need concurrency limits, timeouts, retries, and backoff.
+- SQLite has write-concurrency limits.
+- Multi-worker deployments should run one scheduler or use leader election/locking.
+- Reports and evidence bundles should have a retention policy.
+
+Recommended starting points:
+
+| Setting | Starting recommendation |
+|---|---|
+| Max upload size | 25 MB per file unless you have tested larger policies |
+| Audit timeout | 60-120 seconds per request |
+| PDF timeout | `CASHEL_PDF_TIMEOUT_MS=30000` to `60000` |
+| Scheduled audit concurrency | 1-3 concurrent SSH audits |
+| Worker count | 1 for small hosts; scale only after scheduler behavior is controlled |
+| Report retention | 30-90 days, shorter for highly sensitive environments |
+| Storage | Persistent volume for DB, reports, uploads, and keys |
+| Backups | SQLite plus `CASHEL_KEY_FILE` together |
+
+More detail: [docs/performance.md](docs/performance.md) and [docs/operations.md](docs/operations.md).
+
+---
+
+## Licensing Direction
+
+Cashel is MIT licensed. The current code still contains a legacy license mechanism that gates compliance checks in some workflows. That implementation is deprecated and under review.
+
+Current behavior:
+
+- Hygiene audits run without a license.
+- Compliance checks may be skipped unless a local license key is present.
+- Demo mode bypasses licensing for hosted demo behavior.
+- The active code still exposes license activation/deactivation routes and UI copy.
+
+Preferred direction:
+
+- Remove paid compliance gating unless a strong reason remains.
+- Treat compliance as a data-quality and evidence-mapping problem, not a paid unlock.
+- Make compliance controls data-driven and mapped to stable finding IDs.
+- Include evidence, affected object/rule, remediation, verification, and status in compliance exports.
+- Remove stale purchase links and paid-feature claims from product docs and UI.
+
+Tracking docs: [docs/product-contract.md](docs/product-contract.md)
+
+---
+
+## Compliance Direction
+
+Compliance support is useful only when it is evidence-backed and auditable.
+
+Current behavior:
+
+- Supported framework labels include CIS, DISA STIG, HIPAA, NIST, PCI-DSS, and SOC2.
+- Current checks map some findings to framework-style labels.
+- Some workflows still require the legacy license state before compliance checks run.
+
+Future behavior:
+
+- Control mappings should be stored as data, not hard-coded scattered logic.
+- Controls should map to stable finding IDs and normalized finding fields.
+- Compliance exports should include evidence, affected object/rule, remediation, verification, and implementation status.
+- Compliance should not overstate coverage. A framework label should identify mapped checks, not full certification readiness.
 
 ---
 
 ## Installation
 
-### Option 1 — Docker Compose
+### Docker Compose
 
-**Requirements:** Docker Desktop, OrbStack, or another Docker-compatible runtime.
+Requirements: Docker Desktop, OrbStack, or another Docker-compatible runtime.
 
 ```bash
 git clone https://github.com/Shamrock13/cashel.git
@@ -180,33 +263,25 @@ cd cashel
 docker compose up --build
 ```
 
-Open **http://localhost:8080**.
+Open `http://localhost:8080`.
 
-Reports, audit history, activity log, schedules, and license settings persist in Docker storage across restarts.
-
-Recommended `.env` value:
+Recommended `.env` values for persistent self-hosted use:
 
 ```bash
 CASHEL_SECRET=replace-with-a-long-random-secret
+CASHEL_KEY_FILE=/data/cashel.key
+CASHEL_DB=/data/cashel.db
+UPLOAD_FOLDER=/data/uploads
+REPORTS_FOLDER=/data/reports
+PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+CASHEL_SECURE_COOKIES=true
 ```
 
-For Render Docker deployments, mount a persistent disk at `/data` and set
-`UPLOAD_FOLDER=/data/uploads`, `REPORTS_FOLDER=/data/reports`,
-`LICENSE_PATH=/data/.cashel_license`, `CASHEL_KEY_FILE=/data/cashel.key`, and
-`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`. Without persistent `/data`, setup,
-history, schedules, reports, and license state reset when the container is
-replaced. The first Docker build can take longer because Chromium is installed
-for PDF generation.
+The Docker build installs Playwright Chromium for PDF generation. First builds can take longer while the browser is downloaded.
 
-Stop the app:
+### Local Python
 
-```bash
-docker compose down
-```
-
-### Option 2 — Local Python
-
-**Requirements:** Python 3.9+.
+Requirements: Python 3.9+.
 
 ```bash
 git clone https://github.com/Shamrock13/cashel.git
@@ -221,47 +296,17 @@ Run the web UI:
 PYTHONPATH=src python -m flask --app src/cashel/web.py run
 ```
 
-Open **http://localhost:5000**.
-
 Run the CLI:
 
 ```bash
 PYTHONPATH=src python -m cashel.main --file examples/cisco_asa.txt --vendor cisco
 ```
 
-### PDF rendering notes
-
-Cashel renders audit, remediation, and evidence-bundle PDFs from HTML/CSS report templates. Playwright's Chromium browser is required for PDF export.
-
-Optional environment variables:
-
-```bash
-CASHEL_PDF_PAGE_FORMAT=Letter
-CASHEL_PDF_TIMEOUT_MS=30000
-```
+CLI reference: [docs/cli.md](docs/cli.md)
 
 ---
 
-## Quick Start
-
-```bash
-# Cisco ASA example
-PYTHONPATH=src python -m cashel.main --file examples/cisco_asa.txt --vendor cisco
-
-# Palo Alto example
-PYTHONPATH=src python -m cashel.main --file examples/palo_alto.xml --vendor paloalto
-
-# Web UI
-PYTHONPATH=src python -m flask --app src/cashel/web.py run
-```
-
-Full CLI reference: [docs/cli.md](docs/cli.md)
-
----
-
-## Web UI
-
-The interface is organized into six main areas:
+## Web UI Areas
 
 | Area | Purpose |
 |---|---|
@@ -270,13 +315,11 @@ The interface is organized into six main areas:
 | Live Connect | Pull and audit running configs over SSH |
 | History | Browse saved audits, compare previous runs, and view trends |
 | Schedules | Manage recurring SSH audits and alert behavior |
-| Settings | Configure email, security settings, syslog, webhooks, license, and app preferences |
+| Settings | Configure auth, email, security settings, syslog, webhooks, compliance access, and app preferences |
 
 ---
 
 ## Example Config Files
-
-The `examples/` directory contains sample configurations for supported vendors.
 
 | File | Vendor |
 |---|---|
@@ -294,50 +337,23 @@ The `examples/` directory contains sample configurations for supported vendors.
 
 ---
 
-## Development Status
+## Development
+
+```bash
+python3 -m ruff format src/ tests/
+python3 -m ruff check src/ tests/
+python3 -m mypy src/cashel/ --ignore-missing-imports
+python3 -m pytest tests/ -q
+git diff --check
+```
 
 Current version in `pyproject.toml`: **2.0.0**.
-
-Recently added or in-flight on the current development branch:
-
-- Modern HTML/CSS-rendered audit PDFs
-- Modern remediation PDFs
-- Report view page
-- HTML-based evidence bundle cover PDFs
-- Normalized finding model
-- Evidence-backed ASA findings
-- Enriched shadow-rule findings across supported ordered-rule vendors
-- Remediation plans that prefer structured fields over regex parsing
-- JSON/CSV/SARIF enriched-field export support
-- Expanded tests for reports, exports, remediation, HTML PDF rendering, and finding normalization
-
-Known cleanup still needed:
-
-- Replace placeholder package author metadata in `pyproject.toml`
-- Continue migrating non-ASA vendor checks to enriched findings
-- Add deeper object/service expansion for Fortinet, Palo Alto, and ASA/FTD
-- Refactor compliance mappings toward data-driven controls
-- Build policy-as-code gates after the finding model is consistently adopted
-
----
-
-## Roadmap Priority
-
-Near-term development should focus on depth and trust:
-
-1. Finish structured finding migration for Fortinet and Palo Alto
-2. Add object and service expansion for Fortinet, Palo Alto, and ASA/FTD
-3. Make shadow detection scope-aware for CIDRs, ports, nested groups, and service objects
-4. Improve compliance mapping using stable finding IDs
-5. Add policy-as-code gates for CI/CD after findings are consistently normalized
-
-Cashel should avoid adding more vendors until the top vendors produce consistently evidence-backed results.
 
 ---
 
 ## License
 
-The core tool is open source under the MIT License. The compliance module requires a paid license key.
+Cashel is released under the MIT License.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@
 PYTHONPATH=src python -m cashel.main --file config.txt --vendor asa
 ```
 
-## With compliance checks (license required)
+## With compliance checks (legacy gate under review)
 
 ```bash
 PYTHONPATH=src python -m cashel.main --file config.txt --vendor asa --compliance pci
@@ -48,8 +48,13 @@ Omit `--vendor` to use auto-detection.
 
 ## License activation
 
+The legacy compliance gate still exists in some code paths, but paid compliance
+licensing is deprecated and under review. These commands are retained for
+compatibility while compliance is refactored toward data-driven evidence
+mapping.
+
 ```bash
-# Activate
+# Activate a legacy local key
 PYTHONPATH=src python -m cashel.main --activate YOUR-LICENSE-KEY
 
 # Deactivate

--- a/docs/deployment-hardening.md
+++ b/docs/deployment-hardening.md
@@ -1,0 +1,109 @@
+# Deployment Hardening
+
+This guide summarizes production hardening expectations for self-hosted Cashel deployments.
+
+## Baseline
+
+- Run behind a TLS-terminating reverse proxy.
+- Do not expose Gunicorn directly to the internet.
+- Set `CASHEL_SECRET` to a strong stable secret.
+- Set and persist `CASHEL_KEY_FILE`.
+- Use persistent storage for SQLite, reports, uploads, and key material.
+- Set `CASHEL_SECURE_COOKIES=true` when served over HTTPS.
+- Keep `WEB_CONCURRENCY=1` unless scheduler leadership is controlled.
+
+## Reverse Proxy
+
+Forward:
+
+- `Host`
+- `X-Forwarded-For`
+- `X-Forwarded-Proto`
+- `X-Real-IP`
+
+Recommended proxy controls:
+
+- HTTPS only
+- HSTS at the proxy
+- Request body limit aligned with max upload policy
+- Read timeout long enough for bounded audits and PDFs
+- Access logs with sensitive-query redaction where possible
+
+## OIDC/SSO Readiness
+
+Planned environment variables:
+
+```bash
+CASHEL_AUTH_MODE=local|oidc
+CASHEL_OIDC_ISSUER=https://idp.example.com/
+CASHEL_OIDC_CLIENT_ID=cashel
+CASHEL_OIDC_CLIENT_SECRET=replace-me
+CASHEL_OIDC_REDIRECT_URI=https://cashel.example.com/auth/oidc/callback
+CASHEL_OIDC_ALLOWED_DOMAINS=example.com
+CASHEL_OIDC_ADMIN_GROUPS=Cashel Admins
+CASHEL_OIDC_AUDITOR_GROUPS=Network Engineers
+CASHEL_OIDC_VIEWER_GROUPS=Security Viewers
+```
+
+Provider targets:
+
+- Microsoft Entra ID
+- Google Workspace
+- Okta
+- Authentik
+- Keycloak
+
+SAML is future roadmap. Keep local auth for bootstrap/fallback, and restrict fallback admin credentials.
+
+## Containers
+
+Recommended environment:
+
+```bash
+CASHEL_SECRET=<strong-random-secret>
+CASHEL_KEY_FILE=/data/cashel.key
+CASHEL_DB=/data/cashel.db
+UPLOAD_FOLDER=/data/uploads
+REPORTS_FOLDER=/data/reports
+PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+CASHEL_SECURE_COOKIES=true
+WEB_CONCURRENCY=1
+```
+
+Mount persistent storage at `/data`. Back up `/data/cashel.db` and `/data/cashel.key` together.
+
+## File and Report Retention
+
+Suggested defaults:
+
+- Upload temp files: delete immediately after processing where possible.
+- Reports and evidence bundles: 30-90 days unless client requirements say otherwise.
+- Activity and auth logs: 90-180 days for small deployments.
+- Backups: encrypted at rest and tested for restore.
+
+## Network Egress
+
+Restrict outbound access for:
+
+- Webhooks
+- Slack/Teams
+- SMTP
+- Syslog
+- OIDC discovery/token/userinfo endpoints after SSO is implemented
+
+Use allowlists and monitor unexpected destinations.
+
+## Scheduler Hardening
+
+Until leader election or scheduler locking exists:
+
+- Run a single scheduler process.
+- Avoid multiple Gunicorn workers that each start schedulers.
+- Use explicit SSH timeouts.
+- Limit concurrent scheduled audits.
+- Add retries with backoff instead of tight retry loops.
+
+## Demo Mode
+
+`CASHEL_DEMO_MODE=true` is for hosted demos. Do not use it for production.
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,7 +51,7 @@ Set `CASHEL_PDF_PAGE_FORMAT` to override the default `Letter` page size, or
 | `CASHEL_DB` | No | `/data/cashel.db` | SQLite database path. |
 | `UPLOAD_FOLDER` | No | `/tmp/cashel_uploads` | Temporary uploaded config storage. Use `/data/uploads` in Docker/Render so the path is writable. |
 | `REPORTS_FOLDER` | No | `/tmp/cashel_reports` | Generated report storage. Use `/data/reports` in Docker/Render. |
-| `LICENSE_PATH` | No | platform config path | License file path. Use `/data/.cashel_license` in Docker/Render so license state persists. |
+| `LICENSE_PATH` | No | platform config path | Legacy compliance access file path. This gate is deprecated and under review; use `/data/.cashel_license` only if you must preserve current compatibility behavior. |
 | `PLAYWRIGHT_BROWSERS_PATH` | No | Playwright default | Browser install path. Docker images set this to `/ms-playwright` for non-root PDF rendering. |
 | `CASHEL_SECURE_COOKIES` | No | `false` | Set to `true` when serving over HTTPS. Marks session cookie with `Secure` flag. |
 | `WEB_CONCURRENCY` | No | `1` | Gunicorn worker count. Keep at `1` on single-CPU hosts to avoid OOM. |
@@ -189,9 +189,9 @@ docker compose up -d
 ## Render Docker deployment
 
 For Render Docker services, add a persistent disk mounted at `/data`. Without a
-persistent `/data` mount, the setup page, audit history, schedules, license
-state, reports, uploads, and encryption key can reset when Render replaces the
-container.
+persistent `/data` mount, the setup page, audit history, schedules, legacy
+compliance access state, reports, uploads, and encryption key can reset when
+Render replaces the container.
 
 Recommended Render environment:
 
@@ -200,7 +200,7 @@ CASHEL_SECRET=<strong-random-secret>
 PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 UPLOAD_FOLDER=/data/uploads
 REPORTS_FOLDER=/data/reports
-LICENSE_PATH=/data/.cashel_license
+LICENSE_PATH=/data/.cashel_license  # legacy compatibility only
 CASHEL_KEY_FILE=/data/cashel.key
 CASHEL_DB=/data/cashel.db
 WEB_CONCURRENCY=1

--- a/docs/gumroad-listing.md
+++ b/docs/gumroad-listing.md
@@ -1,78 +1,14 @@
-# Gumroad Product Listing — Cashel
+# Deprecated Commercial Listing
 
-## Product Name
-Cashel — Firewall Configuration Auditor
+This file used to hold draft third-party storefront sales copy. That direction is deprecated.
 
-## Tagline
-Audit any firewall in seconds. Find misconfigurations, score your security posture, and prove compliance — from the command line or a web browser.
+Cashel's current product direction is:
 
-## Description
+- Self-hosted firewall auditing for engineers, MSPs, and security teams
+- Evidence-backed, reproducible findings
+- Fortinet, Palo Alto, and Cisco ASA/FTD depth before new vendor breadth
+- SSO/OIDC readiness
+- Security hardening and operational clarity
+- Compliance as data-driven evidence mapping, not a paid unlock assumption
 
-Cashel is a firewall auditing tool that reads your configuration files and tells you exactly what's wrong — and how to fix it.
-
-Point it at a Cisco ASA config, a Palo Alto XML export, an AWS Security Group dump, or a plain iptables ruleset. Within seconds you get a 0–100 security score, severity-ranked findings, and step-by-step remediation guidance. No cloud upload. No agent. No subscription required to use the core tool.
-
-**What Cashel checks:**
-- Any-any permit rules (the silent killer in every network)
-- Missing ingress/egress logging
-- Absent default-deny policies
-- Redundant, shadowed, and duplicate rules
-- Overly permissive administrative access
-- Weak encryption and legacy protocol usage
-- And more — vendor-specific checks per platform
-
-**Supported platforms (11 vendor platforms):**
-- Cisco ASA and FTD
-- Palo Alto Networks (PAN-OS XML)
-- Fortinet FortiGate
-- pfSense
-- Juniper SRX (set-style and hierarchical)
-- iptables and nftables
-- AWS Security Groups (JSON)
-- Azure Network Security Groups (JSON)
-- GCP VPC Firewall Rules (JSON)
-
-**Multiple ways to audit:**
-- Upload a config file via the web UI
-- Bulk-audit multiple configs at once
-- Connect live to a device over SSH (on-premises vendors; cloud platforms import JSON exports)
-- Schedule recurring audits with Slack, Teams, or email alerts
-- Run from the command line (`cashel --vendor asa --file myconfig.txt`)
-- Call via REST API from your CI/CD pipeline (`POST /api/v1/audit`)
-
-**Export everything:**
-PDF reports, JSON, CSV, and SARIF (for GitHub Code Scanning and other SAST tools).
-
-**Compare configs over time:**
-Diff two configs side by side to see exactly what changed between audits — score deltas and new/resolved findings included (supported for Cisco ASA/FTD, Palo Alto, FortiGate, pfSense, AWS, and Azure).
-
----
-
-**Compliance frameworks (paid license — included with purchase):**
-
-Cashel maps findings to six frameworks so you can generate audit-ready evidence without manual cross-referencing:
-
-- CIS Benchmark
-- DISA STIG
-- HIPAA
-- NIST SP 800-41
-- PCI-DSS
-- SOC 2
-
-One license key. No recurring fees. Activate offline.
-
----
-
-**Who uses Cashel:**
-- Homelab operators who want to know if their edge firewall is actually doing its job
-- Freelance consultants and MSPs auditing client environments before handing over a report
-- Security engineers who need compliance evidence without a six-figure GRC platform
-- DevOps teams who want firewall audits in their CI/CD pipeline alongside code scans
-- Enterprise security teams who need a lightweight second opinion alongside their SIEM
-
-**Try before you buy:** [demo.cashel.app](https://demo.cashel.app) — full UI, real sample configs, no account required.
-
-## Pricing Notes (fill in before publishing)
-- Price: $_____
-- License: Single-user perpetual (one key, unlimited audits)
-- Delivery: Instant — license key emailed automatically after purchase
+Do not publish this file as a product listing. If commercial packaging is revisited, rewrite it from the product contract in [product-contract.md](product-contract.md) and avoid claims that imply equal maturity across every supported vendor.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,96 @@
+# Operations
+
+This runbook covers day-to-day operations for a self-hosted Cashel deployment.
+
+## Startup
+
+Required before production use:
+
+- `CASHEL_SECRET` set
+- `CASHEL_KEY_FILE` present and persistent
+- SQLite path on persistent storage
+- Upload/report directories writable
+- TLS reverse proxy configured
+- Secure cookies enabled over HTTPS
+
+Health endpoint:
+
+```bash
+curl -f http://localhost:5000/health
+```
+
+## Backups
+
+Back up together:
+
+- SQLite database
+- `CASHEL_KEY_FILE`
+- Reports/evidence bundles if they are compliance records
+
+Test restore regularly. A restored database without the matching key file may not be able to decrypt stored scheduled credentials.
+
+## Upgrades
+
+Recommended process:
+
+1. Stop new scheduled jobs.
+2. Back up DB and key file.
+3. Pull/build the new image.
+4. Start one instance.
+5. Check `/health`.
+6. Run a small known-good audit.
+7. Re-enable scheduled jobs.
+
+## Retention
+
+Define explicit retention for:
+
+- Audit history
+- Activity/auth logs
+- Uploaded configs
+- Generated reports
+- Evidence bundles
+- Webhook delivery records
+
+For sensitive customer/MSP environments, shorter report retention plus external controlled evidence storage may be preferable.
+
+## Scheduler Operations
+
+Until scheduler leader election/locking exists:
+
+- Run a single scheduler process.
+- Keep `WEB_CONCURRENCY=1` unless you are certain only one worker runs the scheduler.
+- Set device command timeouts.
+- Use bounded retries and backoff.
+- Monitor repeated authentication failures.
+
+## Incident Response
+
+If secrets may be exposed:
+
+1. Rotate local passwords/API keys.
+2. Rotate webhook and SMTP secrets.
+3. Rotate OIDC client secret after SSO exists.
+4. Decide whether `CASHEL_SECRET` must be rotated and accept session invalidation.
+5. Do not rotate `CASHEL_KEY_FILE` without a decrypt/re-encrypt migration.
+
+If reports or configs leak:
+
+1. Treat them as sensitive network architecture disclosure.
+2. Identify affected devices/customers.
+3. Review generated evidence bundles and exports.
+4. Rotate device credentials if configs include secrets.
+5. Remove artifacts from storage and backups according to policy.
+
+## Monitoring
+
+Monitor:
+
+- Failed logins and invalid API-key events
+- Audit failures
+- Scheduled run failures
+- PDF generation failures/timeouts
+- Webhook/syslog delivery failures
+- Disk usage for reports and uploads
+- SQLite backup success
+

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,83 @@
+# Performance and Scaling
+
+Cashel is currently optimized for self-hosted engineering workflows and small team/MSP deployments. It is not yet designed as a horizontally scaled SaaS control plane.
+
+## Heavy Operations
+
+### PDF Generation
+
+PDF generation starts Chromium through Playwright. This can be CPU and memory heavy.
+
+Mitigations:
+
+- Set `CASHEL_PDF_TIMEOUT_MS`.
+- Limit concurrent PDF generation.
+- Prefer JSON/CSV/SARIF for automation.
+- Keep report retention bounded.
+- Run image rebuilds regularly so Chromium dependencies stay patched.
+
+### Bulk Audits
+
+Bulk audits currently run in request/response flow.
+
+Mitigations:
+
+- Enforce max upload size.
+- Limit number of files per request.
+- Keep reverse proxy timeouts aligned with expected audit duration.
+- Move large bulk jobs to a background queue in future work.
+
+### Scope-Aware Shadow Analysis
+
+Future scope-aware analysis can become expensive with nested object groups, service groups, CIDRs, zones, and NAT context.
+
+Mitigations:
+
+- Cache object and service expansion.
+- Memoize nested group resolution.
+- Avoid naive unbounded `O(n^2)` pairwise comparisons where indexed or ordered approaches are possible.
+- Apply depth limits and cycle detection for nested groups.
+- Emit partial-analysis warnings rather than timing out silently.
+
+## SQLite
+
+SQLite is acceptable for lightweight self-hosted deployments. It has write-concurrency limits.
+
+Mitigations:
+
+- Keep worker count low.
+- Avoid long write transactions.
+- Back up regularly.
+- Consider future database abstraction before high-concurrency deployments.
+
+## Scheduler
+
+Scheduled SSH audits need explicit concurrency controls.
+
+Risks:
+
+- Long-running SSH commands block schedules.
+- Device outages can create retry storms.
+- Multi-worker deployments can duplicate scheduler runs.
+
+Mitigations:
+
+- Set SSH timeouts.
+- Limit scheduled audit concurrency.
+- Use retries with backoff.
+- Run one scheduler process.
+- Add leader election or locking before multi-worker scheduler deployments.
+
+## Recommended Starting Values
+
+| Control | Recommendation |
+|---|---|
+| Max upload size | 25 MB per file |
+| Audit timeout | 60-120 seconds |
+| PDF timeout | 30-60 seconds |
+| Scheduled audit concurrency | 1-3 |
+| Gunicorn workers | 1 for small hosts |
+| Report retention | 30-90 days |
+| SQLite backup | Daily for active installs |
+| Persistent storage | Required for production |
+

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -1,0 +1,92 @@
+# Cashel Product Contract
+
+Cashel's contract is simple: produce trusted, evidence-backed, reproducible firewall audit findings that engineers can verify and remediate. Vendor breadth is secondary to correctness, explainability, and operational safety.
+
+## Current Priority Order
+
+1. Product truth / docs cleanup
+2. License decision/removal
+3. SSO/OIDC model
+4. Security hardening docs
+5. Performance/scaling guardrails
+6. NormalizedRule / NormalizedFinding model completion
+7. Stable finding IDs everywhere
+8. Evidence-backed vendor migration
+9. Scope-aware analysis
+10. Fortinet/Palo Alto/ASA depth
+11. Policy-as-code / CI gates
+12. MSP-grade reporting
+
+## Feature Matrix
+
+| Area | Status | Product contract |
+|---|---|---|
+| Single-file audit | Implemented | Deterministic parser-backed audit of one uploaded config. |
+| Bulk audit | Implemented | Multiple uploaded configs audited independently; needs stronger bounds for large deployments. |
+| Live SSH audit | Implemented | Pulls running configs from supported platforms; one-time credentials are not stored. |
+| Scheduled SSH audit | Partial | Recurring audits exist with encrypted saved credentials; needs concurrency, timeout, and scheduler leadership hardening. |
+| Audit history | Implemented | Stores audit summaries, findings, tags, activity, and report references. |
+| Activity/auth logging | Implemented | Records operational events; retention policy is deployment responsibility today. |
+| Modern audit PDFs | Implemented | HTML/CSS templates rendered through Playwright/Chromium. |
+| Remediation PDFs | Implemented | Structured remediation output with evidence fields where findings provide them. |
+| Evidence bundles | Implemented | ZIP exports with report artifacts and machine-readable outputs. |
+| JSON export | Implemented | Preserves enriched finding dictionaries. |
+| CSV export | Implemented | Includes normalized columns where available. |
+| SARIF export | Implemented | Uses stable finding IDs when present; legacy findings remain supported. |
+| NormalizedFinding model | Partial | Model exists and newer checks use it; legacy string findings still appear. |
+| NormalizedRule model | Planned | Needed for scope-aware policy analysis and policy-as-code gates. |
+| Stable finding IDs | Partial | Present for many enriched findings; not universal. |
+| Evidence-backed vendor findings | Partial | Strongest in ASA and improving in Fortinet/Palo Alto; not complete everywhere. |
+| Cisco ASA/FTD depth | Partial | Primary near-term platform. ASA has object/object-group expansion and enriched findings; FTD needs continued depth. |
+| Fortinet depth | Partial | Enriched findings and object expansion exist; needs more complete service/address behavior. |
+| Palo Alto depth | Partial | XML parsing, object/service/application expansion, and enriched findings exist; needs deeper scope semantics. |
+| Juniper/pfSense depth | Partial | Useful audit coverage exists; not the current top depth priority. |
+| Cloud firewall depth | Experimental | AWS/Azure/GCP are useful static checks but not the current depth priority. |
+| Scope-aware shadowing | Partial | Existing shadow checks catch useful cases but are not fully context-aware. |
+| Compliance checks | Deprecated | Current implementation is license-gated in some flows and should be reworked toward data-driven mappings. |
+| License-gated compliance | Deprecated | Do not build new product direction around paid compliance gating. |
+| OIDC SSO | Planned | First-class target. Local auth remains bootstrap/fallback. |
+| SAML SSO | Planned | Future roadmap after OIDC. |
+| Policy-as-code / CI gates | Planned | Depends on stable IDs and normalized findings/rules. |
+| MSP-grade reporting | Planned | Needs better tenant/client presentation, retention controls, and evidence review workflows. |
+
+## Vendor Maturity
+
+| Vendor family | Status | Notes |
+|---|---|---|
+| Cisco ASA / FTD | Mature / enriched | ASA has the strongest normalized/evidence-backed coverage. Continue ASA/FTD depth before adding new vendors. |
+| Fortinet FortiGate | Mature / enriched | Good parser direction with address/service expansion; continue hardening object semantics. |
+| Palo Alto Networks | Mature / enriched | Good XML/parser direction with object/service/application expansion; continue scope-aware analysis. |
+| Juniper SRX | Partial / legacy-compatible | Useful checks and some enrichment, but not uniform. |
+| pfSense | Partial / legacy-compatible | Useful checks and alias expansion, but not uniform. |
+| iptables / nftables | Partial / legacy-compatible | Useful host-firewall checks. |
+| Azure NSG | Partial / legacy-compatible | Priority-based checks exist. |
+| AWS Security Groups | Experimental / basic audit only | Basic static checks. |
+| GCP VPC Firewall | Experimental / basic audit only | Basic static checks. |
+
+## Compliance Direction
+
+Current compliance behavior is not the long-term contract. It is partially implemented and may be license-gated depending on route and deployment state.
+
+Future compliance should be data-driven:
+
+- Controls map to stable finding IDs.
+- Controls define required evidence fields.
+- Exports include evidence, affected object/rule, remediation, verification, and status.
+- Framework labels do not imply full certification readiness.
+- Control mappings can be tested independently from parser logic.
+
+## SSO Direction
+
+OIDC should be the first SSO target. The intended providers are Microsoft Entra ID, Google Workspace, Okta, Authentik, and Keycloak. SAML is deferred.
+
+Planned role mapping:
+
+| IdP claim/group | Cashel role |
+|---|---|
+| `CASHEL_OIDC_ADMIN_GROUPS` | `admin` |
+| `CASHEL_OIDC_AUDITOR_GROUPS` | `auditor` |
+| `CASHEL_OIDC_VIEWER_GROUPS` | `viewer` |
+
+Local auth should remain available for bootstrap/fallback, but production deployments should prefer SSO once implemented.
+

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,62 @@
+# Secrets
+
+Cashel has a small number of secrets that determine whether sessions and encrypted stored credentials survive restarts.
+
+## Required Production Secrets
+
+| Secret | Purpose | Requirement |
+|---|---|---|
+| `CASHEL_SECRET` | Flask session and CSRF signing | Long random value, stable across restarts |
+| `CASHEL_KEY_FILE` | Fernet key for encrypted stored secrets | Persistent file, backed up with SQLite |
+| OIDC client secret | Future SSO token exchange | Store in environment/secret manager, not repo |
+| SMTP password | Email alerts | Stored encrypted when saved through Cashel |
+| Webhook HMAC secrets | Generic webhook signing | Stored encrypted where supported |
+| Scheduled SSH passwords | Recurring device pulls | Stored encrypted with `CASHEL_KEY_FILE` |
+
+## Generating Secrets
+
+```bash
+openssl rand -hex 32
+```
+
+```bash
+python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Write the Fernet key to the configured `CASHEL_KEY_FILE` path once. Do not regenerate it unless you intentionally want to invalidate encrypted stored secrets.
+
+## Backup Rule
+
+Back up these together:
+
+- SQLite database
+- `CASHEL_KEY_FILE`
+- Reports if you need historical evidence artifacts
+
+If the database is restored without the matching Fernet key, scheduled SSH credentials and other encrypted values may be unrecoverable.
+
+## Rotation
+
+`CASHEL_SECRET` rotation invalidates sessions. Rotate during a maintenance window.
+
+`CASHEL_KEY_FILE` rotation requires a migration plan that decrypts existing values with the old key and re-encrypts with the new key. Do not replace the file blindly.
+
+## What Not To Commit
+
+Never commit:
+
+- `.env`
+- SQLite files
+- key files
+- license files
+- uploaded configs
+- generated PDFs
+- evidence bundles
+- webhook URLs or secrets
+- OIDC secrets
+- real firewall configs
+
+## Legacy License State
+
+`LICENSE_PATH` is a legacy compliance-gating artifact. It may still affect current compliance behavior, but it is deprecated and under review. Do not build new deployment workflows around a paid license file.
+

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,139 @@
+# Security Model
+
+Cashel is self-hosted software that processes sensitive firewall and network-control-plane data. Treat the application, database, reports, uploads, and exports as sensitive infrastructure records.
+
+## Sensitive Data
+
+Cashel may handle:
+
+- Uploaded firewall configurations
+- Live SSH hostnames, usernames, passwords, and private keys
+- Scheduled SSH credentials
+- Audit findings that expose topology, policy gaps, and security weaknesses
+- Generated PDFs, evidence bundles, CSV, JSON, and SARIF files
+- API keys, local user records, and auth events
+- Webhook URLs, HMAC secrets, SMTP credentials, and syslog targets
+
+## Authentication and Authorization
+
+Current behavior:
+
+- Local users are created during first-run setup.
+- Local sessions and API keys are supported.
+- Roles are admin, auditor, and viewer style access patterns.
+- Local auth can be disabled for simple deployments.
+
+Target behavior:
+
+- `CASHEL_AUTH_MODE=local|oidc`
+- Local auth remains bootstrap/fallback.
+- OIDC is the first SSO target.
+- SAML is future roadmap.
+- Role mapping comes from IdP claims/groups:
+  - `CASHEL_OIDC_ADMIN_GROUPS`
+  - `CASHEL_OIDC_AUDITOR_GROUPS`
+  - `CASHEL_OIDC_VIEWER_GROUPS`
+
+OIDC deployment requirements:
+
+- HTTPS is required.
+- Set `CASHEL_SECURE_COOKIES=true`.
+- Configure exact callback URL: `CASHEL_OIDC_REDIRECT_URI`.
+- Preserve proxy headers, especially `Host` and `X-Forwarded-Proto`.
+- Restrict local fallback accounts and document break-glass access.
+
+## Secrets
+
+`CASHEL_SECRET` signs Flask sessions and CSRF tokens. It must be long, random, and stable across restarts. If it changes, active sessions are invalidated.
+
+`CASHEL_KEY_FILE` stores the Fernet key used for encrypted secrets such as scheduled SSH passwords and API-key material. It must persist across restarts and be backed up with the SQLite database. If it is lost, encrypted stored secrets cannot be decrypted.
+
+Never commit:
+
+- `CASHEL_SECRET`
+- `CASHEL_KEY_FILE`
+- SQLite databases
+- Uploaded configs
+- Generated reports
+- License files
+- Webhook, SMTP, or OIDC secrets
+
+## Uploaded Configs and Reports
+
+Firewall configs and generated artifacts can contain:
+
+- Internal IP ranges
+- Hostnames
+- Interface names
+- VPN peers
+- Access-control policy
+- Security gaps
+- Change history and evidence
+
+Use persistent storage with restricted filesystem permissions. Apply retention policies for uploads, reports, evidence bundles, and audit history.
+
+## Live SSH and Scheduled Credentials
+
+Live SSH one-time credentials should not be stored. Scheduled SSH credentials are stored encrypted and depend on `CASHEL_KEY_FILE`.
+
+Recommendations:
+
+- Prefer least-privilege read-only device accounts.
+- Use strict SSH host-key policy in production.
+- Set command timeouts.
+- Limit scheduled audit concurrency.
+- Rotate credentials and remove old schedules.
+- Back up DB and key file together.
+
+## CSRF, Cookies, and Rate Limiting
+
+Cashel uses Flask-WTF CSRF protections for browser workflows and rate limiting on sensitive routes. Production deployments should:
+
+- Serve only over HTTPS.
+- Set `CASHEL_SECURE_COOKIES=true`.
+- Keep `CASHEL_SECRET` stable and private.
+- Forward real client IPs from the reverse proxy.
+- Avoid exposing the app directly without TLS.
+
+## XML Parsing Safety
+
+XML inputs use safe parsing patterns and CI checks prevent use of unsafe `xml.etree` imports under `src/cashel`. Keep using `defusedxml` for untrusted XML configs.
+
+## Webhooks and Syslog
+
+Outbound integrations can leak sensitive audit metadata. Webhook SSRF controls and allowlists reduce risk, but egress should also be controlled at the network layer.
+
+Recommendations:
+
+- Allowlist only known webhook hostnames.
+- Use HMAC secrets for generic webhooks.
+- Avoid sending full findings to broad external channels unless approved.
+- Treat syslog destinations as sensitive egress.
+- Monitor webhook delivery failures and unexpected destinations.
+
+## Playwright/PDF Runtime
+
+PDF rendering starts Chromium through Playwright. This is useful but heavier than plain JSON/CSV export.
+
+Recommendations:
+
+- Keep Playwright browsers installed in a known read-only path for containers.
+- Set `CASHEL_PDF_TIMEOUT_MS`.
+- Avoid unbounded concurrent PDF generation.
+- Treat PDF files as sensitive artifacts.
+- Keep browser dependencies patched through regular image rebuilds.
+
+## Demo Mode
+
+Demo mode is intended for hosted demos only. It may bypass licensing and disable persistent write operations. Do not use demo mode as a production security boundary.
+
+## Audit and Retention Expectations
+
+Cashel records audits, auth events, activity logs, schedule runs, and failures. Operators should define:
+
+- How long audit history is retained
+- How reports and bundles are deleted
+- How SQLite backups are protected
+- Who can export evidence
+- Who can delete archived data
+

--- a/src/cashel/blueprints/api_v1.py
+++ b/src/cashel/blueprints/api_v1.py
@@ -174,6 +174,8 @@ def api_audit():
 
         findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
+        # TODO: Remove or refactor this legacy compliance access gate.
+        # Compliance should become data-driven evidence mapping, not a paid unlock.
         if compliance and vendor not in ("aws", "azure", "gcp", "iptables", "nftables"):
             licensed, _ = check_license()
             if licensed:

--- a/src/cashel/blueprints/audit.py
+++ b/src/cashel/blueprints/audit.py
@@ -425,16 +425,16 @@ def run_audit():
     try:
         findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
-        # Compliance checks (license-gated; not applicable for AWS/Azure)
+        # TODO: Remove or refactor this legacy compliance access gate.
+        # Compliance should become data-driven evidence mapping, not a paid unlock.
         license_warning = None
         if compliance and vendor not in ("aws", "azure", "gcp", "iptables", "nftables"):
             licensed, _ = check_license()
             if not licensed:
                 license_warning = (
-                    "Compliance checks require a valid license. "
-                    'Purchase one at <a href="https://shamrock13.gumroad.com/l/cashel" '
-                    'target="_blank" rel="noopener">shamrock13.gumroad.com/l/cashel</a>. '
-                    "Once purchased, enter your key in Settings → Licensing."
+                    "Compliance checks are currently behind a deprecated legacy "
+                    "access gate and may be skipped until that gate is removed "
+                    "or refactored."
                 )
             else:
                 raw = run_compliance_checks(vendor, compliance, parse, extra_data)
@@ -693,6 +693,7 @@ def live_connect():
     try:
         findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
+        # TODO: Remove or refactor this legacy compliance access gate.
         if compliance and vendor not in ("aws", "azure", "gcp", "iptables", "nftables"):
             licensed, _ = check_license()
             if licensed:
@@ -832,6 +833,7 @@ def bulk_audit():
 
             findings, parse, extra_data = run_vendor_audit(vendor, temp_path)
 
+            # TODO: Remove or refactor this legacy compliance access gate.
             if compliance and vendor not in (
                 "aws",
                 "azure",

--- a/src/cashel/main.py
+++ b/src/cashel/main.py
@@ -1,5 +1,4 @@
 import typer
-from rich.console import Console
 from .license import activate_license, check_license, deactivate_license
 from .reporter import generate_report
 from .audit_engine import (
@@ -9,7 +8,6 @@ from .audit_engine import (
     run_vendor_audit,
 )
 
-_console = Console()
 app = typer.Typer()
 
 _VALID_VENDORS = [
@@ -87,15 +85,12 @@ def audit(
         typer.echo("[PASS] No issues found")
 
     if compliance:
+        # TODO: Remove or refactor this legacy compliance access gate.
         licensed, message = check_license()
         if not licensed:
-            typer.echo("\n⚠️  Compliance checks require a valid license.")
-            _console.print(
-                "   Purchase a license at: [link=https://shamrock13.gumroad.com/l/cashel]"
-                "https://shamrock13.gumroad.com/l/cashel[/link]"
-            )
+            typer.echo("\nCompliance checks are behind a deprecated legacy gate.")
             typer.echo(
-                "   Once purchased, activate your key: cashel --activate YOUR-LICENSE-KEY"
+                "This behavior is under review; hygiene checks still run without a key."
             )
             raise typer.Exit()
         typer.echo(f"\n--- {compliance.upper()} Compliance Checks ---")

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -101,9 +101,9 @@
           <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>
         </svg>
       </button>
-      <span class="license-chip{% if not licensed %} unlicensed{% endif %}" id="licenseChip" role="button" tabindex="0" title="{% if licensed %}Open Licensing settings{% else %}Compliance checks disabled — click to activate a license{% endif %}">
+      <span class="license-chip{% if not licensed %} unlicensed{% endif %}" id="licenseChip" role="button" tabindex="0" title="{% if licensed %}Open compliance access settings{% else %}Legacy compliance access inactive — click for status{% endif %}">
         <span class="dot" id="licDot"></span>
-        <span id="licenseText">{% if licensed %}Licensed{% else %}Unlicensed{% endif %}</span>
+        <span id="licenseText">{% if licensed %}Compliance on{% else %}Compliance off{% endif %}</span>
         {% if not licensed %}
         <svg class="arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         {% endif %}
@@ -689,7 +689,7 @@
             <div class="field">
               <div>
                 <div class="label">Scope</div>
-                <div class="help">Compliance checks are license-gated and run after the hygiene audit.</div>
+                <div class="help">Compliance checks currently use legacy access gating and run after the hygiene audit.</div>
               </div>
               <div class="ctrl">
                 <select class="select" id="connCompliance" name="compliance" {% if demo_mode %}disabled{% endif %}>
@@ -1188,7 +1188,7 @@
 
           <a data-pane="licensing" href="#">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 12l2 2 4-4"/><circle cx="12" cy="12" r="9"/></svg>
-            Licensing
+            Compliance Access
           </a>
 
           <a data-pane="webhooks" href="#">
@@ -1656,36 +1656,36 @@
             </div>
           </div>
 
-          <!-- Licensing pane -->
+          <!-- Compliance access pane -->
           <div class="settings-pane" id="spane-licensing">
-            <h2>Licensing</h2>
-            <p class="section-desc">Cashel runs a free hygiene engine out of the box. A license unlocks compliance frameworks (HIPAA, CIS Benchmark v8, NIST 800-53, PCI-DSS 4.0) and removes the per-run watermark on PDF reports.</p>
+            <h2>Compliance Access</h2>
+            <p class="section-desc">Cashel's hygiene engine runs without a license. The older compliance gate is still present for compatibility, but paid compliance licensing is deprecated and under review.</p>
 
-            <div class="sub-head">Current license</div>
+            <div class="sub-head">Current access state</div>
             <div class="lic-card">
               <div class="lic-card-row">
                 <div>
                   <div class="lic-status{% if licensed %} ok{% endif %}" id="licStatusBlock">
                     <span class="lic-status-dot"></span>
-                    <span class="lic-status-text">{% if licensed %}Cashel Pro &middot; active{% else %}No active license{% endif %}</span>
+                    <span class="lic-status-text">{% if licensed %}Legacy compliance access active{% else %}Legacy compliance access inactive{% endif %}</span>
                   </div>
-                  <div class="lic-status-help" id="licStatusHelp">{% if licensed %}All compliance frameworks unlocked. Renewal and seat usage shown to the right.{% else %}Compliance checks require a valid key. Hygiene scanning continues to work without one.{% endif %}</div>
+                  <div class="lic-status-help" id="licStatusHelp">{% if licensed %}Compliance checks currently run for supported frameworks. This gate is deprecated and may be removed or refactored.{% else %}Compliance checks may be skipped until the legacy gate is removed. Hygiene scanning continues to work.{% endif %}</div>
                 </div>
                 <div class="lic-meta" id="licMetaBlock"{% if not licensed %} style="display:none"{% endif %}>
-                  <div class="lic-meta-row"><span class="lab">Plan</span><span class="val">Cashel Pro</span></div>
-                  <div class="lic-meta-row"><span class="lab">Seats</span><span class="val">5 engines</span></div>
-                  <div class="lic-meta-row"><span class="lab">Renews</span><span class="val">Mar 14, 2027</span></div>
+                  <div class="lic-meta-row"><span class="lab">Mode</span><span class="val">Legacy compatibility</span></div>
+                  <div class="lic-meta-row"><span class="lab">Status</span><span class="val">Deprecated</span></div>
+                  <div class="lic-meta-row"><span class="lab">Direction</span><span class="val">Under review</span></div>
                   <div class="lic-meta-row"><span class="lab">Key</span><span class="val mono" id="licMetaKey">{{ license_info if licensed else 'CSL-••••••••-••••••••-••••••••-••••••••-••••••••' }}</span></div>
                 </div>
               </div>
             </div>
 
-            <div class="sub-head">Activate a license key</div>
+            <div class="sub-head">Legacy key activation</div>
             <div class="form">
               <div class="field split license-activation-field">
                 <div>
-                  <div class="label">License key</div>
-                  <div class="help">Paste the key from your purchase email. Activation is local — no telemetry.</div>
+                  <div class="label">Legacy access key</div>
+                  <div class="help">Activation is local and exists for compatibility while compliance gating is reviewed.</div>
                 </div>
                 <div class="ctrl">
                   <input class="input mono" id="licenseKeyInput" placeholder="CSL-XXXXXXXX-XXXXXXXX-XXXXXXXX-XXXXXXXX" autocomplete="off" />
@@ -1695,7 +1695,7 @@
               <div class="field">
                 <div>
                   <div class="label">Offline activation</div>
-                  <div class="help">Air-gapped install? Generate a request file, upload it at cashel.app/activate, then import the response.</div>
+                  <div class="help">Placeholder controls retained for compatibility. No external activation service is required for the current local key check.</div>
                 </div>
                 <div class="ctrl">
                   <div style="display:flex;gap:8px;flex-wrap:wrap;">
@@ -1706,17 +1706,17 @@
               </div>
             </div>
 
-            <div class="sub-head" style="margin-top:2rem">What a license unlocks</div>
+            <div class="sub-head" style="margin-top:2rem">Direction</div>
             <div class="lic-features">
-              <div class="lic-feat"><span class="dot"></span><div><div class="t">Compliance frameworks</div><div class="d">HIPAA Security Rule, CIS Benchmark v8, NIST 800-53, PCI-DSS 4.0.</div></div></div>
-              <div class="lic-feat"><span class="dot"></span><div><div class="t">Bulk + scheduled audits</div><div class="d">Run more than 3 configs at once and schedule recurring audits.</div></div></div>
-              <div class="lic-feat"><span class="dot"></span><div><div class="t">Branded PDF reports</div><div class="d">Remove the evaluation watermark and add your organisation lockup.</div></div></div>
-              <div class="lic-feat"><span class="dot"></span><div><div class="t">Priority support</div><div class="d">Email response within one business day, plus signed-build access.</div></div></div>
+              <div class="lic-feat"><span class="dot"></span><div><div class="t">Compliance as evidence mapping</div><div class="d">Future controls should map to stable finding IDs and normalized evidence fields.</div></div></div>
+              <div class="lic-feat"><span class="dot"></span><div><div class="t">No paid unlock assumption</div><div class="d">Paid compliance gating is deprecated unless a stronger product reason emerges.</div></div></div>
+              <div class="lic-feat"><span class="dot"></span><div><div class="t">Data-driven controls</div><div class="d">Framework mappings should move out of scattered code paths and into testable data.</div></div></div>
+              <div class="lic-feat"><span class="dot"></span><div><div class="t">Policy-as-code readiness</div><div class="d">Compliance exports should include evidence, affected object, remediation, verification, and status.</div></div></div>
             </div>
 
             <div style="padding-top:28px;display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
-              <button type="button" class="btn-danger" id="deactivateLicenseBtn" style="{% if not licensed %}display:none;{% endif %}">Deactivate license</button>
-              <a href="https://shamrock13.gumroad.com/l/cashel" target="_blank" rel="noopener" class="btn-outline action-pill-control license-buy-link">Buy a license</a>
+              <button type="button" class="btn-danger" id="deactivateLicenseBtn" style="{% if not licensed %}display:none;{% endif %}">Deactivate legacy key</button>
+              <a href="https://github.com/Shamrock13/cashel/blob/main/docs/product-contract.md" target="_blank" rel="noopener" class="btn-outline action-pill-control license-buy-link">View product contract</a>
               <span style="margin-left:auto;color:var(--ink-3);font-size:13px;">Need help? <a href="mailto:support@cashel.app" class="ulink">support@cashel.app</a></span>
             </div>
 
@@ -2092,13 +2092,13 @@
     if (chip && badge) {
       if (isLicensed) {
         chip.classList.remove('unlicensed');
-        chip.title = 'Open Licensing settings';
-        badge.textContent = 'Licensed';
+        chip.title = 'Open compliance access settings';
+        badge.textContent = 'Compliance on';
         const arr = chip.querySelector('.arrow'); if (arr) arr.remove();
       } else {
         chip.classList.add('unlicensed');
-        chip.title = 'Compliance checks disabled — click to activate a license';
-        badge.textContent = 'Unlicensed';
+        chip.title = 'Legacy compliance access inactive — click for status';
+        badge.textContent = 'Compliance off';
         if (!chip.querySelector('.arrow')) {
           const arr = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
           arr.setAttribute('class', 'arrow');
@@ -2124,15 +2124,15 @@
       const t = sb.querySelector('.lic-status-text');
       if (isLicensed) {
         sb.classList.add('ok');
-        if (t) t.textContent = 'Cashel Pro · active';
-        if (sh) sh.textContent = 'All compliance frameworks unlocked. Renewal and seat usage shown to the right.';
+        if (t) t.textContent = 'Legacy compliance access active';
+        if (sh) sh.textContent = 'Compliance checks currently run for supported frameworks. This gate is deprecated and may be removed or refactored.';
         if (sm) sm.style.display = '';
         if (sk && key) sk.textContent = maskLicenseKey(key);
         if (db) db.style.display = '';
       } else {
         sb.classList.remove('ok');
-        if (t) t.textContent = 'No active license';
-        if (sh) sh.textContent = 'Compliance checks require a valid key. Hygiene scanning continues to work without one.';
+        if (t) t.textContent = 'Legacy compliance access inactive';
+        if (sh) sh.textContent = 'Compliance checks may be skipped until the legacy gate is removed. Hygiene scanning continues to work.';
         if (sm) sm.style.display = 'none';
         if (db) db.style.display = 'none';
       }

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -639,7 +639,7 @@ class TestModalMarkup(unittest.TestCase):
         ):
             self.assertIn(selector, css)
 
-    def test_license_purchase_and_activate_button_are_polished(self):
+    def test_legacy_compliance_access_actions_are_polished(self):
         body = self._index_template()
         style_path = os.path.join(
             os.path.dirname(__file__), "..", "src", "cashel", "static", "style.css"
@@ -647,10 +647,15 @@ class TestModalMarkup(unittest.TestCase):
         with open(style_path, encoding="utf-8") as fh:
             css = fh.read()
 
-        self.assertIn('href="https://shamrock13.gumroad.com/l/cashel"', body)
+        self.assertIn(
+            'href="https://github.com/Shamrock13/cashel/blob/main/docs/product-contract.md"',
+            body,
+        )
         self.assertIn('class="btn-outline action-pill-control license-buy-link"', body)
         self.assertIn("support@cashel.app", body)
         self.assertNotIn("support@cashel.dev", body)
+        self.assertIn("paid compliance licensing is deprecated", body)
+        self.assertNotIn("Buy a license", body)
         self.assertIn(
             'class="btn-primary action-pill-control btn-activate-license" id="activateLicenseBtn">Activate</button>',
             body,


### PR DESCRIPTION
## Summary
- Align README and docs with Cashel's current self-hosted, engineer-first product direction
- Add product contract, security model, deployment hardening, secrets, performance, and operations docs
- Mark legacy compliance license gating as deprecated/under review and remove active purchase messaging
- Add TODOs around legacy compliance gates and document OIDC/SSO direction

## Validation
- python3 -m ruff format src/ tests/
- python3 -m ruff check src/ tests/
- python3 -m mypy src/cashel/ --ignore-missing-imports
- python3 -m pytest tests/ -q: 460 passed
- git diff --check