### PR TITLE
Polish demo mode UX and add static asset cache busting

### DIFF
--- a/src/cashel/static/style.css
+++ b/src/cashel/static/style.css
@@ -519,9 +519,15 @@ html[data-theme="dark"] .run-row .rn-score.bad  { color: oklch(0.78 0.18 25); }
 .spinner { width: 16px; height: 16px; border: 2px solid var(--line); border-top-color: var(--ink); border-radius: 50%; animation: spin .7s linear infinite; flex-shrink: 0; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-.demo-banner { background: color-mix(in oklab, var(--med) 14%, var(--surface)); border-bottom: 1px solid color-mix(in oklab, var(--med) 30%, var(--line)); padding: 10px 0; font-size: 13px; text-align: center; color: color-mix(in oklab, var(--med) 60%, var(--ink)); }
+.demo-banner { background: color-mix(in oklab, var(--med) 10%, var(--surface)); border-bottom: 1px solid color-mix(in oklab, var(--med) 26%, var(--line)); padding: 10px 24px; font-size: 13px; text-align: center; color: color-mix(in oklab, var(--med) 58%, var(--ink)); display: flex; align-items: center; justify-content: center; gap: 12px; flex-wrap: wrap; line-height: 1.45; }
 .demo-banner strong { font-weight: 600; }
-.demo-banner a { color: inherit; text-decoration: underline; }
+.demo-banner a { color: inherit; text-decoration: none; }
+.demo-banner-icon { width: 16px; height: 16px; flex-shrink: 0; }
+.demo-banner-link { display: inline-flex; align-items: center; gap: 6px; min-height: 28px; padding: 4px 9px; border-radius: 999px; border: 1px solid color-mix(in oklab, var(--med) 24%, var(--line)); background: color-mix(in oklab, var(--surface) 86%, transparent); font-weight: 500; }
+.demo-banner-link svg { width: 14px; height: 14px; flex: 0 0 auto; }
+.demo-banner-link:hover { border-color: color-mix(in oklab, var(--med) 44%, var(--line)); background: color-mix(in oklab, var(--med) 12%, var(--surface)); }
+.demo-banner-close { width: 28px; height: 28px; border-radius: 50%; display: inline-grid; place-items: center; flex: 0 0 auto; color: inherit; }
+.demo-banner-close:hover { background: color-mix(in oklab, var(--med) 12%, transparent); }
 
 .input.error { border-bottom-color: var(--crit); }
 .field-error { font-size: 12px; color: var(--crit); margin-top: 4px; }

--- a/src/cashel/templates/index.html
+++ b/src/cashel/templates/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="csrf-token" content="{{ csrf_token() }}" />
   <title>Cashel &mdash; Firewall Audit</title>
-  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}" />
+  <link rel="icon" type="image/svg+xml" href="{{ static_asset('favicon.svg') }}" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <link rel="stylesheet" href="{{ static_asset('style.css') }}" />
   <script nonce="{{ g.csp_nonce }}">
 (function(){
   var html = document.documentElement;
@@ -61,9 +61,12 @@
 
   {% if demo_mode %}
   <div class="demo-banner" id="demoBanner" role="banner">
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true" style="width:16px;height:16px;flex-shrink:0"><circle cx="10" cy="10" r="8"/><path d="M10 7v3M10 13h.01"/></svg>
-    <span><strong>Live Demo</strong> &mdash; Sample configs are processed in memory and never stored. No account required.</span>
-    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">&#128196; Sample Report</a>
+    <svg class="demo-banner-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="10" cy="10" r="8"/><path d="M10 7v3M10 13h.01"/></svg>
+    <span><strong>Live Demo</strong> &mdash; Sample configs are processed in memory and never stored.</span>
+    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 2.8h5l3 3V17H6z"/><path d="M11 2.8V6h3"/><path d="M8.5 10h3M8.5 13h3"/></svg>
+      <span>Sample Report</span>
+    </a>
     <a href="https://github.com/shamrock13/cashel" target="_blank" rel="noopener" class="demo-banner-link">Get Cashel &rarr;</a>
     <button class="demo-banner-close" id="demoBannerClose" aria-label="Dismiss">&times;</button>
   </div>
@@ -71,9 +74,9 @@
 
   {% if not demo_mode and not current_user %}
   <div class="demo-banner" style="background:var(--surface-alt,#f0f4ff);color:var(--text,#1a1a2e);border-bottom:1px solid var(--border,#d0d5ea);">
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true" style="width:16px;height:16px;flex-shrink:0"><path d="M4 4h12v12H4z"/><path d="M8 8h4M8 11h4M8 14h2"/></svg>
+    <svg class="demo-banner-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="M4 4h12v12H4z"/><path d="M8 8h4M8 11h4M8 14h2"/></svg>
     <span>See what a Cashel audit report looks like &mdash; no account needed.</span>
-    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">&#128196; View Sample Report &rarr;</a>
+    <a href="/demo/sample-report.pdf" target="_blank" rel="noopener" class="demo-banner-link">View Sample Report &rarr;</a>
   </div>
   {% endif %}
 
@@ -101,6 +104,7 @@
           <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>
         </svg>
       </button>
+      {% if not demo_mode %}
       <span class="license-chip{% if not licensed %} unlicensed{% endif %}" id="licenseChip" role="button" tabindex="0" title="{% if licensed %}Open Licensing settings{% else %}Compliance checks disabled — click to activate a license{% endif %}">
         <span class="dot" id="licDot"></span>
         <span id="licenseText">{% if licensed %}Licensed{% else %}Unlicensed{% endif %}</span>
@@ -108,6 +112,7 @@
         <svg class="arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         {% endif %}
       </span>
+      {% endif %}
       <span class="user">
         <span>{{ current_user.username if current_user and current_user.is_authenticated else 'admin' }}</span>
         <span class="avatar">{{ (current_user.username[0] | upper) if current_user and current_user.is_authenticated else 'A' }}</span>
@@ -135,7 +140,7 @@
     <a data-tab="history" href="#">
       History
     </a>
-    {% if not current_user or current_user.role == 'admin' %}
+    {% if not demo_mode and (not current_user or current_user.role == 'admin') %}
     <a data-tab="settings" href="#">
       Settings
     </a>
@@ -689,7 +694,7 @@
             <div class="field">
               <div>
                 <div class="label">Scope</div>
-                <div class="help">Compliance checks are license-gated and run after the hygiene audit.</div>
+                <div class="help">{% if demo_mode %}Sample compliance checks can be included in demo runs.{% else %}Compliance checks are license-gated and run after the hygiene audit.{% endif %}</div>
               </div>
               <div class="ctrl">
                 <select class="select" id="connCompliance" name="compliance" {% if demo_mode %}disabled{% endif %}>
@@ -1139,6 +1144,7 @@
       </div>
     </section>
 
+    {% if not demo_mode %}
     <!-- ════════════════════════════════════════════════ SETTINGS ══════ -->
     <section class="tab-panel hidden" id="tab-settings">
       <header class="page-head">
@@ -1858,6 +1864,7 @@
         </div><!-- /.settings-main -->
       </div><!-- /.settings -->
     </section>
+    {% endif %}
 
   </main>
 
@@ -2037,6 +2044,7 @@
   });
   _syncAppearanceUI();
 
+  {% if not demo_mode %}
   function maskLicenseKey(key) {
     const parts = key.split("-");
     if (parts.length >= 2) {
@@ -2138,6 +2146,7 @@
       }
     }
   }
+  {% endif %}
 
   const DEMO_MODE = {{ 'true' if demo_mode else 'false' }};
   const userRole = {{ (current_user.role if current_user else 'admin') | tojson }};
@@ -2157,6 +2166,7 @@
   }
   navLinks.forEach(a => a.addEventListener("click", e => { e.preventDefault(); switchTab(a.dataset.tab); }));
 
+  {% if not demo_mode %}
   document.getElementById("licenseChip")?.addEventListener("click", gotoLicensing);
   document.getElementById("licenseChip")?.addEventListener("keydown", e => {
     if (e.key === "Enter" || e.key === " ") {
@@ -2164,6 +2174,7 @@
       gotoLicensing();
     }
   });
+  {% endif %}
 
   // ════════════════════════════════════════ AUDIT MODE TOGGLE (v2 segmented) ══
   function switchAuditMode(mode) {
@@ -2767,7 +2778,7 @@
     }
 
     const warn = document.getElementById("licenseWarning");
-    const warnings = [data.license_warning, data.report_warning].filter(Boolean);
+    const warnings = [(DEMO_MODE ? null : data.license_warning), data.report_warning].filter(Boolean);
     if (warnings.length) { warn.textContent = warnings.join(" "); warn.classList.remove("hidden"); }
     else { warn.classList.add("hidden"); }
 
@@ -4819,7 +4830,7 @@
 
   // Load settings on startup — admin only; non-admin roles get 403 and have
   // sensible JS-side defaults (auto_pdf:false, auto_archive:false, default_compliance:"")
-  if (userRole === 'admin') loadSettings();
+  if (!DEMO_MODE && userRole === 'admin') loadSettings();
 
   {% if demo_mode %}
   // ── Demo mode: audit single-file picker (cards already in DOM) ──────────────

--- a/src/cashel/templates/login.html
+++ b/src/cashel/templates/login.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="csrf-token" content="{{ csrf_token() }}" />
   <title>Cashel &mdash; Login</title>
-  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}" />
+  <link rel="icon" type="image/svg+xml" href="{{ static_asset('favicon.svg') }}" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <link rel="stylesheet" href="{{ static_asset('style.css') }}" />
   <script>
     (function(){
       try {

--- a/src/cashel/templates/setup.html
+++ b/src/cashel/templates/setup.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="csrf-token" content="{{ csrf_token() }}" />
   <title>Cashel &mdash; Setup</title>
-  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}" />
+  <link rel="icon" type="image/svg+xml" href="{{ static_asset('favicon.svg') }}" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <link rel="stylesheet" href="{{ static_asset('style.css') }}" />
   <script>
     (function(){
       try {

--- a/src/cashel/web.py
+++ b/src/cashel/web.py
@@ -4,7 +4,7 @@ import os
 import secrets
 import time
 
-from flask import Flask, g, jsonify, render_template, request
+from flask import Flask, g, jsonify, render_template, request, url_for
 from flasgger import Swagger
 
 from .extensions import csrf, limiter
@@ -91,6 +91,41 @@ _swagger = Swagger(
 )
 
 _start_time = time.time()
+
+
+_asset_build_id = (
+    os.environ.get("CASHEL_ASSET_VERSION")
+    or os.environ.get("RENDER_GIT_COMMIT")
+    or os.environ.get("SOURCE_VERSION")
+    or ""
+).strip()
+
+
+def _static_asset_version(filename: str) -> str:
+    version_parts = []
+    if _asset_build_id:
+        version_parts.append(_asset_build_id[:12])
+    try:
+        static_folder = app.static_folder
+        if static_folder:
+            static_path = os.path.join(static_folder, filename)
+            version_parts.append(str(int(os.path.getmtime(static_path))))
+    except OSError:
+        pass
+    if version_parts:
+        return "-".join(version_parts)
+    try:
+        return importlib.metadata.version("cashel")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+@app.context_processor
+def _static_asset_helpers():
+    def static_asset(filename: str) -> str:
+        return url_for("static", filename=filename, v=_static_asset_version(filename))
+
+    return {"static_asset": static_asset}
 
 
 @app.before_request

--- a/tests/test_ci_smoke.py
+++ b/tests/test_ci_smoke.py
@@ -107,6 +107,30 @@ def test_flask_app_starts_and_serves_health(ci_client):
     assert "uptime_seconds" in data
 
 
+def test_demo_homepage_uses_versioned_assets_and_hides_license_ui(monkeypatch):
+    import cashel.license as license_mod
+    import cashel.web as web_mod
+
+    monkeypatch.setattr(web_mod, "DEMO_MODE", True)
+    monkeypatch.setattr(license_mod, "DEMO_MODE", True)
+    web_mod.app.config["TESTING"] = True
+    web_mod.app.config["WTF_CSRF_ENABLED"] = False
+    web_mod.app.config["WTF_CSRF_CHECK_DEFAULT"] = False
+    web_mod.app.config["RATELIMIT_ENABLED"] = False
+
+    resp = web_mod.app.test_client().get("/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Live Demo" in body
+    assert "/static/style.css?v=" in body
+    assert "/static/favicon.svg?v=" in body
+    assert "licenseChip" not in body
+    assert 'data-tab="settings"' not in body
+    assert "click to activate a license" not in body
+    assert "Buy a license" not in body
+
+
 def test_single_file_audit_smoke(ci_client):
     resp = _post_single_audit(ci_client, archive="1")
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -429,7 +429,53 @@ class TestModalMarkup(unittest.TestCase):
 
         self.assertIn("data.report_warning", body)
         self.assertIn(
-            "const warnings = [data.license_warning, data.report_warning].filter(Boolean);",
+            "const warnings = [(DEMO_MODE ? null : data.license_warning), data.report_warning].filter(Boolean);",
+            body,
+        )
+
+    def test_static_assets_use_cache_busting_helper(self):
+        body = self._index_template()
+
+        self.assertIn("{{ static_asset('favicon.svg') }}", body)
+        self.assertIn("{{ static_asset('style.css') }}", body)
+        self.assertNotIn("url_for('static', filename='style.css')", body)
+
+    def test_demo_banner_is_public_and_glyph_free(self):
+        body = self._index_template()
+        style_path = os.path.join(
+            os.path.dirname(__file__), "..", "src", "cashel", "static", "style.css"
+        )
+        with open(style_path, encoding="utf-8") as fh:
+            css = fh.read()
+
+        demo_banner = body[
+            body.index("{% if demo_mode %}") : body.index(
+                "{% if not demo_mode and not current_user %}"
+            )
+        ]
+        self.assertIn("<strong>Live Demo</strong>", demo_banner)
+        self.assertIn(
+            "Sample configs are processed in memory and never stored.", demo_banner
+        )
+        self.assertIn(">Sample Report<", demo_banner)
+        self.assertIn(">Get Cashel &rarr;<", demo_banner)
+        self.assertNotIn("&#128196;", demo_banner)
+        self.assertNotIn("Licensed", demo_banner)
+        self.assertIn(".demo-banner {", css)
+        self.assertIn("flex-wrap: wrap", css)
+        self.assertIn(".demo-banner-link", css)
+
+    def test_demo_mode_hides_settings_and_license_affordances(self):
+        body = self._index_template()
+
+        self.assertIn('{% if not demo_mode %}\n      <span class="license-chip', body)
+        self.assertIn(
+            "{% if not demo_mode and (not current_user or current_user.role == 'admin') %}",
+            body,
+        )
+        self.assertIn("if (!DEMO_MODE && userRole === 'admin') loadSettings();", body)
+        self.assertIn(
+            "{% if demo_mode %}Sample compliance checks can be included in demo runs.",
             body,
         )
 


### PR DESCRIPTION
## Summary
- Add stable cache-busting query strings for local static assets using deployment/build metadata and file mtimes
- Clean up the demo banner with SVG iconography, tighter spacing, and no emoji glyphs
- Hide licensing chips, prompts, Settings entry points, and license warnings from rendered demo mode
- Keep licensing backend behavior intact outside demo mode

## Validation
- python3 -m ruff format src/ tests/
- python3 -m ruff check src/ tests/
- python3 -m mypy src/cashel/ --ignore-missing-imports
- python3 -m pytest tests/ -q
- git diff --check
- docker build -t cashel-demo-ux-cache-busting .