### PR TITLE
feat: enrich fortinet findings with evidence

### DIFF
--- a/src/cashel/rule_quality.py
+++ b/src/cashel/rule_quality.py
@@ -81,6 +81,70 @@ def _covers(broad, narrow):
     return n.issubset(b)
 
 
+def _forti_policy_name(policy):
+    return policy.get("name") or f"Policy ID {policy.get('id')}"
+
+
+def _forti_policy_values(policy, key):
+    values = policy.get(key, [])
+    if isinstance(values, list):
+        return values
+    if values:
+        return [values]
+    return []
+
+
+def _forti_policy_context(policy, prefix):
+    profile_fields = {
+        "utm-status": "utm_status",
+        "av-profile": "av_profile",
+        "ips-sensor": "ips_sensor",
+        "application-list": "application_list",
+        "webfilter-profile": "webfilter_profile",
+        "profile-protocol-options": "profile_protocol_options",
+    }
+    context = {
+        f"{prefix}_policy_id": str(policy.get("id") or ""),
+        f"{prefix}_policy_name": _forti_policy_name(policy),
+        f"{prefix}_srcintf": _forti_policy_values(policy, "srcintf"),
+        f"{prefix}_dstintf": _forti_policy_values(policy, "dstintf"),
+        f"{prefix}_srcaddr": _forti_policy_values(policy, "srcaddr"),
+        f"{prefix}_dstaddr": _forti_policy_values(policy, "dstaddr"),
+        f"{prefix}_service": _forti_policy_values(policy, "service"),
+        f"{prefix}_action": policy.get("action", ""),
+        f"{prefix}_logtraffic": policy.get("logtraffic", ""),
+        f"{prefix}_status": policy.get("status", ""),
+        f"{prefix}_schedule": policy.get("schedule", ""),
+        f"{prefix}_nat": policy.get("nat", ""),
+        f"{prefix}_comments": policy.get("comments", ""),
+    }
+    for raw_key, metadata_key in profile_fields.items():
+        context[f"{prefix}_{metadata_key}"] = policy.get(raw_key, "")
+    return context
+
+
+def _forti_shadow_evidence(shadowed_policy, shadowing_policy):
+    shadowed_name = _forti_policy_name(shadowed_policy)
+    shadowing_name = _forti_policy_name(shadowing_policy)
+    fields = [
+        f"shadowed_policy_id={shadowed_policy.get('id')}",
+        f"shadowed_name={shadowed_name}",
+        f"shadowed_srcaddr={','.join(_forti_policy_values(shadowed_policy, 'srcaddr')) or 'unset'}",
+        f"shadowed_dstaddr={','.join(_forti_policy_values(shadowed_policy, 'dstaddr')) or 'unset'}",
+        f"shadowed_service={','.join(_forti_policy_values(shadowed_policy, 'service')) or 'unset'}",
+        f"shadowed_action={shadowed_policy.get('action') or 'unset'}",
+        f"shadowed_logtraffic={shadowed_policy.get('logtraffic') or 'unset'}",
+        f"shadowing_policy_id={shadowing_policy.get('id')}",
+        f"shadowing_name={shadowing_name}",
+        f"shadowing_srcaddr={','.join(_forti_policy_values(shadowing_policy, 'srcaddr')) or 'unset'}",
+        f"shadowing_dstaddr={','.join(_forti_policy_values(shadowing_policy, 'dstaddr')) or 'unset'}",
+        f"shadowing_service={','.join(_forti_policy_values(shadowing_policy, 'service')) or 'unset'}",
+        f"shadowing_action={shadowing_policy.get('action') or 'unset'}",
+        f"shadowing_logtraffic={shadowing_policy.get('logtraffic') or 'unset'}",
+    ]
+    return "; ".join(fields)
+
+
 # ── Palo Alto ────────────────────────────────────────────────────────────────
 
 
@@ -153,18 +217,18 @@ def check_shadow_rules_forti(policies):
     policy covers a superset of its srcaddr, dstaddr, and service scope.
     """
     findings = []
-    active = []  # list of (name, srcaddr, dstaddr, service)
+    active = []  # list of (name, srcaddr, dstaddr, service, policy)
 
     for p in policies:
         if p.get("status") == "disable":
             continue
 
-        name = p.get("name") or f"Policy ID {p.get('id')}"
+        name = _forti_policy_name(p)
         src = p.get("srcaddr", [])
         dst = p.get("dstaddr", [])
         svc = p.get("service", [])
 
-        for e_name, e_src, e_dst, e_svc in active:
+        for e_name, e_src, e_dst, e_svc, e_policy in active:
             if _covers(e_src, src) and _covers(e_dst, dst) and _covers(e_svc, svc):
                 findings.append(
                     _f(
@@ -177,23 +241,29 @@ def check_shadow_rules_forti(policies):
                         id="CASHEL-FORTINET-REDUNDANCY-001",
                         vendor="fortinet",
                         title="Fortinet policy is shadowed",
-                        evidence=f"Policy '{e_name}' covers policy '{name}'",
+                        evidence=_forti_shadow_evidence(p, e_policy),
                         affected_object=name,
+                        rule_id=str(p.get("id") or ""),
                         rule_name=name,
                         confidence="medium",
                         verification="Review policy order and hit counts, then re-run the audit after removing, narrowing, or moving the shadowed policy.",
-                        metadata=_shadow_metadata(
-                            name,
-                            e_name,
-                            source=src,
-                            destination=dst,
-                            service=svc,
-                        ),
+                        rollback="Restore the previous policy order from configuration backup if reordering or removal affects approved traffic.",
+                        metadata={
+                            **_shadow_metadata(
+                                name,
+                                e_name,
+                                source=src,
+                                destination=dst,
+                                service=svc,
+                            ),
+                            **_forti_policy_context(p, "shadowed"),
+                            **_forti_policy_context(e_policy, "shadowing"),
+                        },
                     )
                 )
                 break
 
-        active.append((name, src, dst, svc))
+        active.append((name, src, dst, svc, p))
 
     return findings
 

--- a/tests/test_fortinet_findings.py
+++ b/tests/test_fortinet_findings.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 
 from cashel.export import to_csv, to_json, to_sarif
+from cashel.audit_engine import _findings_to_strings, run_vendor_audit
 from cashel.fortinet import (
     _f,
     audit_fortinet,
@@ -21,6 +22,7 @@ from cashel.fortinet import (
     expand_services,
     parse_fortinet,
 )
+from cashel.models.findings import validate_finding_shape
 from cashel.remediation import generate_plan
 
 TESTS_DIR = os.path.dirname(__file__)
@@ -74,6 +76,16 @@ def _parse_text(config_text):
     return policies
 
 
+def _audit_text(config_text):
+    with tempfile.NamedTemporaryFile("w", suffix=".conf", delete=False) as fh:
+        fh.write(config_text)
+        path = fh.name
+    try:
+        return run_vendor_audit("fortinet", path)
+    finally:
+        os.unlink(path)
+
+
 def test_fortinet_legacy_helper_shape_still_works():
     finding = _f("LOW", "hygiene", "[LOW] Legacy Fortinet finding", "Fix it.")
 
@@ -107,6 +119,23 @@ def test_fortinet_audit_findings_include_ids_titles_and_evidence():
     assert all("id" in f and f["id"].startswith("CASHEL-FORTINET-") for f in findings)
     assert all(f.get("title") for f in findings)
     assert all(f.get("evidence") for f in findings)
+
+
+def test_fortinet_full_audit_preserves_count_severity_and_legacy_strings():
+    findings, _parse, policies = run_vendor_audit(
+        "fortinet", os.path.join(TESTS_DIR, "test_forti.txt")
+    )
+
+    assert policies
+    assert len(findings) == 12
+    assert sum(1 for f in findings if f["severity"] == "HIGH") == 5
+    assert sum(1 for f in findings if f["severity"] == "MEDIUM") == 7
+    assert all(validate_finding_shape(f) == [] for f in findings)
+
+    strings = _findings_to_strings(findings)
+    assert len(strings) == len(findings)
+    assert all(isinstance(message, str) for message in strings)
+    assert any("Overly permissive rule 'Allow-All'" in message for message in strings)
 
 
 def test_fortinet_remediation_plan_consumes_commands_and_evidence():
@@ -470,6 +499,34 @@ end
     assert insecure["metadata"]["insecure_services"] == ["TELNET"]
 
 
+def test_fortinet_shadow_findings_include_policy_evidence_and_context():
+    findings, _parse, _policies = run_vendor_audit(
+        "fortinet", os.path.join(TESTS_DIR, "test_forti.txt")
+    )
+    shadow = next(f for f in findings if f["id"] == "CASHEL-FORTINET-REDUNDANCY-001")
+
+    assert shadow["vendor"] == "fortinet"
+    assert shadow["rule_id"] == "2"
+    assert shadow["affected_object"] == "Allow-Web"
+    assert "shadowed_policy_id=2" in shadow["evidence"]
+    assert "shadowing_policy_id=1" in shadow["evidence"]
+    assert "shadowed_srcaddr=all" in shadow["evidence"]
+    assert "shadowing_service=ALL" in shadow["evidence"]
+    assert shadow["metadata"]["shadowed_policy_id"] == "2"
+    assert shadow["metadata"]["shadowed_policy_name"] == "Allow-Web"
+    assert shadow["metadata"]["shadowed_srcaddr"] == ["all"]
+    assert shadow["metadata"]["shadowed_dstaddr"] == ["WebServer"]
+    assert shadow["metadata"]["shadowed_service"] == ["HTTP", "HTTPS"]
+    assert shadow["metadata"]["shadowed_action"] == "accept"
+    assert shadow["metadata"]["shadowed_logtraffic"] == "all"
+    assert shadow["metadata"]["shadowing_policy_id"] == "1"
+    assert shadow["metadata"]["shadowing_policy_name"] == "Allow-All"
+    assert shadow["metadata"]["shadowing_srcaddr"] == ["all"]
+    assert shadow["metadata"]["shadowing_dstaddr"] == ["all"]
+    assert shadow["metadata"]["shadowing_service"] == ["ALL"]
+    assert shadow["rollback"]
+
+
 def test_duplicate_detection_includes_interfaces_schedule_and_nat():
     base = _policy(
         id="1",
@@ -578,3 +635,41 @@ end
     assert findings[0]["id"] == "CASHEL-FORTINET-REDUNDANCY-002"
     assert findings[0]["metadata"]["expanded_srcaddr"] == ["10.20.10.0 255.255.255.0"]
     assert findings[0]["metadata"]["expanded_service"] == ["tcp/8443"]
+
+
+def test_safe_fortinet_sample_has_no_prioritized_policy_findings():
+    findings, _parse, policies = _audit_text(
+        """
+config firewall policy
+    edit 10
+        set name "Specific Outbound Web"
+        set srcintf "lan"
+        set dstintf "wan1"
+        set srcaddr "TrustedUsers"
+        set dstaddr "ApprovedSaaS"
+        set action accept
+        set service "HTTPS"
+        set schedule "always"
+        set logtraffic all
+        set utm-status enable
+        set av-profile "default"
+        set ips-sensor "strict"
+        set application-list "app-control"
+        set webfilter-profile "web-default"
+    next
+    edit 999
+        set name "Explicit Deny All"
+        set srcintf "any"
+        set dstintf "any"
+        set srcaddr "all"
+        set dstaddr "all"
+        set action deny
+        set service "ALL"
+        set logtraffic all
+    next
+end
+"""
+    )
+
+    assert policies
+    assert findings == []


### PR DESCRIPTION
## Summary
- enrich Fortinet shadowed-policy findings with parser-backed policy evidence
- add Fortinet policy context metadata for shadowed and shadowing policies
- add focused tests for stable IDs, evidence, metadata, legacy string consumers, count/severity expectations, and a safe sample

## Validation
- python3 -m ruff format src/ tests/
- python3 -m ruff check src/ tests/
- python3 -m mypy src/cashel/ --ignore-missing-imports
- python3 -m pytest tests/ -q
- git diff --check