### PR TITLE
feat: enrich gcp findings with evidence

### DIFF
--- a/docs/vendor-enrichment-coverage.md
+++ b/docs/vendor-enrichment-coverage.md
@@ -23,14 +23,10 @@ Status terms:
 | nftables | Default accept policy, any/any accepts, internet-exposed sensitive ports, missing logging before accept, unrestricted ICMP | Fully enriched | Current checks include stable IDs, vendor, evidence, affected object/rule name, confidence, verification, rollback, and table/chain/rule metadata. | Use as the nft host-firewall reference pattern when converting remaining cloud firewall checks. | Low |
 | AWS Security Groups | Wide-open ingress, unrestricted egress, missing descriptions, default security group ingress, large port ranges | Fully enriched | Current checks include stable IDs, vendor, evidence, affected object/rule name where applicable, confidence, verification, rollback, and security group/rule metadata. | Keep enrichment aligned if new AWS check families are added. | Low |
 | Azure NSG | Inbound any-source exposure, unrestricted management access, missing flow log confirmation, high-priority allow-all, broad port ranges, Azure NSG shadow checks | Fully enriched | Current checks include stable IDs, vendor, evidence, affected object/rule name, confidence, verification, rollback, and NSG/rule metadata. | Keep enrichment aligned if new Azure NSG check families are added. | Low |
-| GCP VPC Firewall | Internet ingress, unrestricted egress, default network rules, missing descriptions, disabled rules, broad target scope, unrestricted ICMP | Legacy dict only | Missing stable ID, vendor, title, evidence, affected object/rule name, confidence, verification, rollback, and metadata. | Convert GCP checks to normalized findings with firewall rule name, network, direction, priority, target tags/service accounts, protocols, ports, ranges, and disabled state metadata. | High |
+| GCP VPC Firewall | Internet ingress, unrestricted egress, default network rules, missing descriptions, disabled rules, broad target scope, unrestricted ICMP, high-risk management ports | Fully enriched | Current checks include stable IDs, vendor, evidence, affected object/rule name, confidence, verification, rollback, and firewall rule metadata. | Keep enrichment aligned if new GCP VPC firewall check families are added. | Low |
 
 ## Summary
 
 The strongest evidence-backed coverage is currently ASA/FTD, Fortinet, Palo Alto, Juniper SRX, and pfSense. These vendors already emit normalized dictionaries through `make_finding(...)`, though shadow-rule findings still need richer metadata and rollback guidance on several platforms.
 
-The main remaining legacy normalization gap is the cloud group:
-
-- GCP VPC Firewall
-
-GCP still produces legacy dictionaries with the old severity/category/message/remediation shape. It should be converted with focused tests that preserve current counts/severities and verify stable IDs, evidence, metadata, legacy string conversion, remediation, JSON/CSV/SARIF exports, and safe samples.
+The major cloud firewall paths now emit normalized findings for their current check families. Future vendor work should keep new checks aligned with the evidence-backed finding model and preserve legacy finding consumers.

--- a/src/cashel/gcp.py
+++ b/src/cashel/gcp.py
@@ -19,7 +19,10 @@ Key differences from AWS SGs / Azure NSGs:
 
 from __future__ import annotations
 
+import hashlib
 import json
+
+from .models.findings import make_finding
 
 SENSITIVE_PORTS = {
     "22": "SSH",
@@ -39,13 +42,46 @@ SENSITIVE_PORTS = {
 _ANY_RANGES = {"0.0.0.0/0", "::/0"}
 
 
-def _f(severity, category, message, remediation=""):
-    return {
-        "severity": severity,
-        "category": category,
-        "message": message,
-        "remediation": remediation,
-    }
+def _stable_id(check: str, *parts) -> str:
+    payload = json.dumps([check, *parts], sort_keys=True, default=str)
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:10].upper()
+    return f"CASHEL-GCP-{check.upper().replace('_', '-')}-{digest}"
+
+
+def _f(
+    severity,
+    category,
+    message,
+    remediation="",
+    *,
+    id=None,
+    title=None,
+    evidence=None,
+    affected_object=None,
+    rule_name=None,
+    confidence="medium",
+    impact=None,
+    verification=None,
+    rollback=None,
+    metadata=None,
+):
+    return make_finding(
+        severity,
+        category,
+        message,
+        remediation,
+        id=id,
+        vendor="gcp",
+        title=title,
+        evidence=evidence,
+        affected_object=affected_object,
+        rule_name=rule_name,
+        confidence=confidence,
+        impact=impact,
+        verification=verification,
+        rollback=rollback,
+        metadata=metadata,
+    )
 
 
 # ── Parser ────────────────────────────────────────────────────────────────────
@@ -115,6 +151,113 @@ def _ports_for_proto(proto_dict: dict) -> list[str]:
     return proto_dict.get("ports") or []
 
 
+def _rule_protocols(rule: dict) -> list[str]:
+    protocols = []
+    for proto_dict in rule.get("allowed") or rule.get("denied") or []:
+        protocols.append(str(proto_dict.get("IPProtocol", "")))
+    return protocols
+
+
+def _rule_ports(rule: dict) -> list[str]:
+    ports: list[str] = []
+    for proto_dict in rule.get("allowed") or rule.get("denied") or []:
+        ports.extend(str(port) for port in _ports_for_proto(proto_dict))
+    return ports
+
+
+def _logging_state(rule: dict):
+    if "logConfig" not in rule:
+        return "unknown"
+    log_config = rule.get("logConfig") or {}
+    if isinstance(log_config, dict):
+        return log_config.get("enable", "unknown")
+    return log_config
+
+
+def _rule_metadata(rule: dict, extra: dict | None = None) -> dict:
+    metadata = {
+        "firewall_rule_name": _rule_name(rule),
+        "network": _network_short(rule),
+        "direction": rule.get("direction", ""),
+        "priority": rule.get("priority", ""),
+        "source_ranges": rule.get("sourceRanges", []),
+        "destination_ranges": rule.get("destinationRanges", []),
+        "protocols": _rule_protocols(rule),
+        "ports": _rule_ports(rule),
+        "target_tags": rule.get("targetTags", []),
+        "target_service_accounts": rule.get("targetServiceAccounts", []),
+        "disabled": _is_disabled(rule),
+        "logging_state": _logging_state(rule),
+        "raw_rule_context": rule,
+    }
+    if extra:
+        metadata.update(extra)
+    return metadata
+
+
+def _rule_evidence(rule: dict, proto_dict: dict | None = None, port: str | None = None):
+    proto = (
+        proto_dict.get("IPProtocol", "")
+        if proto_dict
+        else ",".join(_rule_protocols(rule))
+    )
+    ports = [str(port)] if port is not None else _rule_ports(rule)
+    return (
+        f"firewall_rule={_rule_name(rule)}; network={_network_short(rule)}; "
+        f"direction={rule.get('direction', '')}; priority={rule.get('priority', '')}; "
+        f"protocol={proto or 'unset'}; ports={','.join(ports) or 'all'}; "
+        f"source_ranges={','.join(rule.get('sourceRanges', [])) or 'unset'}; "
+        f"destination_ranges={','.join(rule.get('destinationRanges', [])) or 'unset'}; "
+        f"targets={','.join(rule.get('targetTags', []) or rule.get('targetServiceAccounts', [])) or 'all'}; "
+        f"disabled={_is_disabled(rule)}; logging={_logging_state(rule)}"
+    )
+
+
+def _verification_text(name: str) -> str:
+    return (
+        "Review GCP effective firewall rules and re-run the GCP VPC firewall "
+        f"audit to confirm the finding is absent for rule '{name}'."
+    )
+
+
+def _rollback_text() -> str:
+    return (
+        "Restore the previous firewall rule from Cloud Audit Logs, IaC, or a "
+        "saved gcloud firewall-rules export if the change blocks approved traffic."
+    )
+
+
+def _rule_kwargs(
+    rule: dict,
+    check: str,
+    title: str,
+    *,
+    proto_dict: dict | None = None,
+    port: str | None = None,
+    confidence: str = "medium",
+    metadata_extra: dict | None = None,
+) -> dict:
+    return {
+        "id": _stable_id(
+            check,
+            _network_short(rule),
+            _rule_name(rule),
+            rule.get("direction", ""),
+            rule.get("priority", ""),
+            proto_dict or {},
+            port or "",
+        ),
+        "title": title,
+        "evidence": _rule_evidence(rule, proto_dict, port),
+        "affected_object": f"VPC '{_network_short(rule)}'",
+        "rule_name": _rule_name(rule),
+        "confidence": confidence,
+        "verification": _verification_text(_rule_name(rule)),
+        "rollback": _rollback_text(),
+        "metadata": _rule_metadata(rule, metadata_extra),
+    }
+
+
 # ── Checks ────────────────────────────────────────────────────────────────────
 
 
@@ -145,6 +288,14 @@ def check_internet_ingress_gcp(rules: list[dict]) -> list[dict]:
                         f"[HIGH] VPC '{network}' rule '{name}': allows ALL ingress traffic from {src}",
                         f"Restrict 'gcloud compute firewall-rules update {name}' to specific source CIDRs "
                         "and protocols. All-traffic rules expose every port to the internet.",
+                        **_rule_kwargs(
+                            rule,
+                            "internet_ingress_all",
+                            "Internet ingress allows all traffic",
+                            proto_dict=proto_dict,
+                            confidence="high",
+                            metadata_extra={"matched_source_ranges": src},
+                        ),
                     )
                 )
             else:
@@ -158,6 +309,18 @@ def check_internet_ingress_gcp(rules: list[dict]) -> list[dict]:
                                 f"[HIGH] VPC '{network}' rule '{name}': {svc} (TCP/{port}) open to {src}",
                                 f"Remove public {svc} access: 'gcloud compute firewall-rules update {name} "
                                 f"--source-ranges=<trusted-cidr>'. Use IAP or Cloud VPN for administrative access.",
+                                **_rule_kwargs(
+                                    rule,
+                                    "internet_ingress_sensitive",
+                                    f"{svc} exposed to the internet",
+                                    proto_dict=proto_dict,
+                                    port=port,
+                                    confidence="high",
+                                    metadata_extra={
+                                        "matched_source_ranges": src,
+                                        "service": svc,
+                                    },
+                                ),
                             )
                         )
                     elif "-" in port:
@@ -174,6 +337,17 @@ def check_internet_ingress_gcp(rules: list[dict]) -> list[dict]:
                                     f"[MEDIUM] VPC '{network}' rule '{name}': wide port range {port} ({span} ports/{proto}) open to {src}",
                                     f"Restrict port range in rule '{name}' to only the specific ports required. "
                                     "Wide ranges significantly increase attack surface.",
+                                    **_rule_kwargs(
+                                        rule,
+                                        "internet_ingress_wide_port_range",
+                                        "Wide internet-exposed port range",
+                                        proto_dict=proto_dict,
+                                        port=port,
+                                        metadata_extra={
+                                            "matched_source_ranges": src,
+                                            "port_range_span": span,
+                                        },
+                                    ),
                                 )
                             )
                         else:
@@ -184,6 +358,14 @@ def check_internet_ingress_gcp(rules: list[dict]) -> list[dict]:
                                     f"[MEDIUM] VPC '{network}' rule '{name}': port {port}/{proto} open to {src}",
                                     f"Restrict source CIDRs for rule '{name}' to known IP ranges. "
                                     "Avoid 0.0.0.0/0 unless the service is intentionally public-facing.",
+                                    **_rule_kwargs(
+                                        rule,
+                                        "internet_ingress_port",
+                                        "Internet-exposed inbound port",
+                                        proto_dict=proto_dict,
+                                        port=port,
+                                        metadata_extra={"matched_source_ranges": src},
+                                    ),
                                 )
                             )
                     else:
@@ -194,6 +376,14 @@ def check_internet_ingress_gcp(rules: list[dict]) -> list[dict]:
                                 f"[MEDIUM] VPC '{network}' rule '{name}': port {port}/{proto} open to {src}",
                                 f"Restrict source CIDRs for rule '{name}' to known IP ranges. "
                                 "Avoid 0.0.0.0/0 unless the service is intentionally public-facing.",
+                                **_rule_kwargs(
+                                    rule,
+                                    "internet_ingress_port",
+                                    "Internet-exposed inbound port",
+                                    proto_dict=proto_dict,
+                                    port=port,
+                                    metadata_extra={"matched_source_ranges": src},
+                                ),
                             )
                         )
     return findings
@@ -223,6 +413,20 @@ def check_unrestricted_egress_gcp(rules: list[dict]) -> list[dict]:
                         f"[MEDIUM] VPC '{network}' rule '{name}': unrestricted egress to 0.0.0.0/0 (all protocols/ports)",
                         f"Restrict outbound traffic for rule '{name}' to required destinations and ports. "
                         "Unrestricted egress can facilitate data exfiltration and C2 communication.",
+                        **_rule_kwargs(
+                            rule,
+                            "unrestricted_egress",
+                            "Unrestricted egress to the internet",
+                            proto_dict=proto_dict,
+                            confidence="high",
+                            metadata_extra={
+                                "matched_destination_ranges": ", ".join(
+                                    r
+                                    for r in rule.get("destinationRanges", [])
+                                    if r in _ANY_RANGES
+                                )
+                            },
+                        ),
                     )
                 )
                 break  # one finding per rule is enough
@@ -251,6 +455,12 @@ def check_default_network_rules_gcp(rules: list[dict]) -> list[dict]:
                     "Migrate workloads to a dedicated VPC with purpose-built firewall rules. "
                     "The 'default' network's pre-populated rules (default-allow-ssh, default-allow-rdp, etc.) "
                     "are overly permissive for production use.",
+                    **_rule_kwargs(
+                        rule,
+                        "default_network_rules",
+                        "Firewall rules exist on the default VPC network",
+                        metadata_extra={"default_network": True},
+                    ),
                 )
             )
     return findings
@@ -274,6 +484,12 @@ def check_missing_description_gcp(rules: list[dict]) -> list[dict]:
                     f"Add a description: 'gcloud compute firewall-rules update {name} "
                     '--description="<purpose, owner, ticket>"\'. '
                     "Descriptions are essential for security reviews and change management.",
+                    **_rule_kwargs(
+                        rule,
+                        "missing_description",
+                        "Firewall rule is missing a description",
+                        metadata_extra={"description": rule.get("description", "")},
+                    ),
                 )
             )
     return findings
@@ -295,6 +511,31 @@ def check_disabled_rules_gcp(rules: list[dict]) -> list[dict]:
             "Remove disabled rules that are no longer needed. "
             "Disabled rules represent configuration drift and complicate audits. "
             "If a rule may be needed again, document it in a ticket and delete it from the firewall.",
+            id=_stable_id("disabled_rules", [r.get("name", "") for r in disabled]),
+            title="Disabled firewall rules found",
+            evidence=(f"disabled_rules={label}; count={len(disabled)}"),
+            affected_object="GCP firewall disabled rules",
+            rule_name=label,
+            confidence="medium",
+            verification="Confirm disabled firewall rules are deleted or re-enabled intentionally, then re-run the audit.",
+            rollback="Recreate a deleted disabled rule from Cloud Audit Logs, IaC, or a saved firewall-rules export if it is still required.",
+            metadata={
+                "firewall_rule_name": label,
+                "network": "",
+                "direction": "",
+                "priority": "",
+                "source_ranges": [],
+                "destination_ranges": [],
+                "protocols": [],
+                "ports": [],
+                "target_tags": [],
+                "target_service_accounts": [],
+                "disabled": True,
+                "logging_state": "unknown",
+                "disabled_rule_count": len(disabled),
+                "disabled_rule_names": [_rule_name(r) for r in disabled],
+                "raw_rule_context": disabled,
+            },
         )
     ]
 
@@ -326,6 +567,12 @@ def check_no_target_restriction_gcp(rules: list[dict]) -> list[dict]:
                     f"Add target network tags or a target service account to rule '{name}': "
                     f"'gcloud compute firewall-rules update {name} --target-tags=<tag>'. "
                     "Rules without targets apply to every VM in the network, violating least-privilege.",
+                    **_rule_kwargs(
+                        rule,
+                        "broad_target_scope",
+                        "Internet-sourced rule applies to all instances",
+                        metadata_extra={"applies_to_all_instances": True},
+                    ),
                 )
             )
     return findings
@@ -354,6 +601,19 @@ def check_icmp_unrestricted_gcp(rules: list[dict]) -> list[dict]:
                         f"Restrict ICMP to known management CIDRs: "
                         f"'gcloud compute firewall-rules update {name} --source-ranges=<mgmt-cidr>'. "
                         "Unrestricted ICMP aids network reconnaissance.",
+                        **_rule_kwargs(
+                            rule,
+                            "unrestricted_icmp",
+                            "ICMP allowed inbound from the internet",
+                            proto_dict=proto_dict,
+                            metadata_extra={
+                                "matched_source_ranges": ", ".join(
+                                    r
+                                    for r in rule.get("sourceRanges", [])
+                                    if r in _ANY_RANGES
+                                )
+                            },
+                        ),
                     )
                 )
     return findings
@@ -369,7 +629,20 @@ def audit_gcp_firewall(filepath: str) -> tuple[list[dict], list[dict]]:
     """
     rules, error = parse_gcp_firewall(filepath)
     if error:
-        return [_f("HIGH", "parse", f"[HIGH] {error}")], []
+        return [
+            _f(
+                "HIGH",
+                "parse",
+                f"[HIGH] {error}",
+                id=_stable_id("parse_error", error),
+                title="GCP firewall JSON parse error",
+                evidence=error,
+                affected_object=filepath,
+                confidence="high",
+                verification="Confirm the file is a valid GCP firewall-rules JSON export and re-run the audit.",
+                metadata={"firewall_rule_name": "", "raw_rule_context": {}},
+            )
+        ], []
 
     findings: list[dict] = []
     findings += check_internet_ingress_gcp(rules)

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -21,6 +21,9 @@ from cashel.gcp import (
     check_icmp_unrestricted_gcp,
     audit_gcp_firewall,
 )
+from cashel.export import to_csv, to_json, to_sarif
+from cashel.models.findings import validate_finding_shape
+from cashel.remediation import generate_plan
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -331,8 +334,7 @@ def test_audit_gcp_clean():
         findings, rules = audit_gcp_firewall(path)
         assert isinstance(findings, list)
         assert len(rules) == len(RULES_CLEAN)
-        high = [f for f in findings if f["severity"] == "HIGH"]
-        assert len(high) == 0
+        assert findings == []
     finally:
         os.unlink(path)
 
@@ -341,6 +343,128 @@ def test_audit_gcp_parse_error():
     findings, rules = audit_gcp_firewall("/nonexistent/file.json")
     assert len(findings) == 1
     assert rules == []
+
+
+def test_gcp_findings_preserve_count_and_severity_expectations():
+    path = _write_json(RULES_RISKY)
+    try:
+        findings, rules = audit_gcp_firewall(path)
+    finally:
+        os.unlink(path)
+
+    assert len(rules) == len(RULES_RISKY)
+    assert len(findings) == 15
+    assert [f["severity"] for f in findings].count("HIGH") == 4
+    assert [f["severity"] for f in findings].count("MEDIUM") == 11
+    assert any("SSH (TCP/22) open to 0.0.0.0/0" in f["message"] for f in findings)
+    assert any("unrestricted egress to 0.0.0.0/0" in f["message"] for f in findings)
+    assert any(
+        "Firewall rules exist on the 'default' VPC" in f["message"] for f in findings
+    )
+    assert any("no description set" in f["message"] for f in findings)
+    assert any("disabled firewall rule" in f["message"] for f in findings)
+    assert any("applies to ALL instances" in f["message"] for f in findings)
+    assert any("ICMP allowed inbound" in f["message"] for f in findings)
+
+
+def test_gcp_findings_are_enriched_with_stable_ids_and_rule_evidence():
+    path = _write_json(RULES_RISKY)
+    try:
+        findings, _rules = audit_gcp_firewall(path)
+        second_run_ids = [f["id"] for f in audit_gcp_firewall(path)[0]]
+    finally:
+        os.unlink(path)
+
+    assert second_run_ids == [f["id"] for f in findings]
+    for finding in findings:
+        assert finding["id"].startswith("CASHEL-GCP-")
+        assert finding["vendor"] == "gcp"
+        assert finding["title"]
+        assert finding["evidence"]
+        assert finding["affected_object"] or finding["rule_name"]
+        assert finding["confidence"]
+        assert finding["verification"]
+        assert finding["metadata"]["raw_rule_context"]
+        assert "logging_state" in finding["metadata"]
+        assert validate_finding_shape(finding) == []
+
+    rule_backed = [
+        f for f in findings if isinstance(f["metadata"].get("raw_rule_context"), dict)
+    ]
+    assert rule_backed
+    for finding in rule_backed:
+        metadata = finding["metadata"]
+        assert metadata["firewall_rule_name"]
+        assert metadata["network"]
+        assert metadata["direction"] in {"INGRESS", "EGRESS"}
+        assert "priority" in metadata
+        assert metadata["protocols"]
+        assert "source_ranges" in metadata
+        assert "destination_ranges" in metadata
+        assert "target_tags" in metadata
+        assert "target_service_accounts" in metadata
+        assert "disabled" in metadata
+        assert "firewall_rule=" in finding["evidence"]
+
+
+def test_gcp_exports_preserve_enriched_fields():
+    path = _write_json(RULES_RISKY)
+    try:
+        findings, _rules = audit_gcp_firewall(path)
+    finally:
+        os.unlink(path)
+
+    finding = findings[0]
+    entry = {
+        "filename": "gcp-firewall.json",
+        "vendor": "gcp",
+        "summary": {"total": 1},
+        "findings": [finding],
+    }
+
+    json_out = json.loads(to_json(entry))
+    exported = json_out["findings"][0]
+    assert exported["id"] == finding["id"]
+    assert exported["metadata"]["firewall_rule_name"] == "default-allow-ssh"
+    assert exported["evidence"] == finding["evidence"]
+
+    import csv
+    import io
+
+    csv_row = next(csv.DictReader(io.StringIO(to_csv(entry))))
+    assert csv_row["id"] == finding["id"]
+    assert csv_row["vendor"] == "gcp"
+    assert csv_row["evidence"] == finding["evidence"]
+    assert csv_row["affected_object"] == finding["affected_object"]
+    assert csv_row["rule_name"] == finding["rule_name"]
+
+    sarif = json.loads(to_sarif(entry))
+    result = sarif["runs"][0]["results"][0]
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    assert result["ruleId"] == finding["id"]
+    assert rule["id"] == finding["id"]
+    assert result["properties"]["vendor"] == "gcp"
+    assert result["properties"]["evidence"] == finding["evidence"]
+    assert result["properties"]["rule_name"] == finding["rule_name"]
+
+
+def test_gcp_remediation_consumes_enriched_fields():
+    path = _write_json(RULES_RISKY)
+    try:
+        findings, _rules = audit_gcp_firewall(path)
+    finally:
+        os.unlink(path)
+
+    finding = findings[0]
+    plan = generate_plan([finding], "gcp", filename="gcp-firewall.json")
+    step = plan["phases"][0]["steps"][0]
+
+    assert step["title"] == finding["title"]
+    assert step["evidence"] == finding["evidence"]
+    assert step["verification"] == finding["verification"]
+    assert step["rollback"] == finding["rollback"]
+    assert step["affected_object"] == finding["affected_object"]
+    assert "suggested_commands" not in step
 
 
 # ── Standalone runner ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- convert GCP VPC firewall findings to normalized evidence-backed findings
- add stable IDs, evidence, rollback, and firewall rule metadata for current GCP checks
- extend GCP tests for count/severity preservation, metadata, exports, remediation, and safe samples
- mark GCP VPC Firewall fully enriched in vendor coverage docs

## Validation
- python3 -m ruff format src/ tests/
- python3 -m ruff check src/ tests/
- python3 -m mypy src/cashel/ --ignore-missing-imports
- python3 -m pytest tests/ -q
- git diff --check