### PR TITLE
[codex] Gate public API docs by default

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -334,9 +334,20 @@ Use this endpoint for container health checks, load balancer probes, and uptime 
 
 ---
 
+## API Documentation Access
+
+`GET /api/docs` and `GET /apispec.json` require authenticated access by default.
+
+Set `CASHEL_PUBLIC_API_DOCS=true` only when you intentionally want the Swagger UI
+and OpenAPI spec to remain public, such as for a controlled demo environment.
+Truthy values include `true`, `1`, `yes`, and `on`. The default is `false`.
+
+---
+
 ## Hardening Checklist
 
 - [ ] `CASHEL_SECRET` is set and not the default
+- [ ] `CASHEL_PUBLIC_API_DOCS` is unset or `false` unless public API docs are intentional
 - [ ] `CASHEL_KEY_FILE` points to a persistent, backed-up location
 - [ ] `CASHEL_SECURE_COOKIES=true` when behind HTTPS
 - [ ] TLS 1.2+ only on the proxy (TLS 1.3 preferred)

--- a/src/cashel/_helpers.py
+++ b/src/cashel/_helpers.py
@@ -49,9 +49,22 @@ _AUTH_EXEMPT_ENDPOINTS = {
     "audit.demo_sample_report",
 }
 
-# Path prefixes that bypass auth (Swagger UI and spec JSON — public API docs)
-# Path prefixes exempt from auth — Swagger UI + spec JSON are always public
-_AUTH_EXEMPT_PATH_PREFIXES = ("/api/docs", "/flasgger_static/", "/apispec")
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
+# Swagger UI static assets can stay public; the docs UI/spec routes are gated below.
+_AUTH_EXEMPT_PATH_PREFIXES = ("/flasgger_static/",)
+_API_DOCS_PATH_PREFIXES = ("/api/docs", "/apispec")
+
+
+def api_docs_public_enabled() -> bool:
+    """Return whether API docs/spec routes should remain public."""
+    return os.environ.get("CASHEL_PUBLIC_API_DOCS", "false").strip().lower() in (
+        _TRUTHY_ENV_VALUES
+    )
+
+
+def _is_api_docs_path() -> bool:
+    return request.path.startswith(_API_DOCS_PATH_PREFIXES)
 
 
 def _require_auth_impl(demo_mode: bool):
@@ -59,6 +72,9 @@ def _require_auth_impl(demo_mode: bool):
     if demo_mode:
         g.auth_method = "demo"
         g.current_user = None
+        return
+
+    if _is_api_docs_path() and api_docs_public_enabled():
         return
 
     settings = get_settings()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -365,6 +365,122 @@ class TestWebAuth(unittest.TestCase):
         finally:
             self._teardown(tmp, orig, orig_conn)
 
+    def test_health_remains_public_when_auth_enabled(self):
+        client, tmp, orig, orig_conn = self._setup()
+        try:
+            us.create_user("healthadmin", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+
+            resp = client.get("/health")
+
+            self.assertEqual(resp.status_code, 200)
+            self.assertTrue(resp.get_json()["ok"])
+        finally:
+            self._teardown(tmp, orig, orig_conn)
+
+    def test_api_docs_require_auth_by_default(self):
+        client, tmp, orig, orig_conn = self._setup()
+        try:
+            us.create_user("docsadmin", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+            os.environ.pop("CASHEL_PUBLIC_API_DOCS", None)
+
+            resp = client.get("/api/docs", follow_redirects=False)
+
+            self.assertEqual(resp.status_code, 401)
+            self.assertEqual(resp.get_json()["error"], "Authentication required.")
+        finally:
+            self._teardown(tmp, orig, orig_conn)
+
+    def test_apispec_requires_auth_by_default(self):
+        client, tmp, orig, orig_conn = self._setup()
+        try:
+            us.create_user("specadmin", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+            os.environ.pop("CASHEL_PUBLIC_API_DOCS", None)
+
+            resp = client.get("/apispec.json", follow_redirects=False)
+
+            self.assertEqual(resp.status_code, 302)
+            self.assertIn("/login", resp.headers["Location"])
+        finally:
+            self._teardown(tmp, orig, orig_conn)
+
+    def test_public_api_docs_env_keeps_docs_public(self):
+        client, tmp, orig, orig_conn = self._setup()
+        orig_public_docs = os.environ.get("CASHEL_PUBLIC_API_DOCS")
+        try:
+            us.create_user("publicdocs", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+            os.environ["CASHEL_PUBLIC_API_DOCS"] = "true"
+
+            resp = client.get("/api/docs")
+
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn(b"swagger", resp.data.lower())
+        finally:
+            if orig_public_docs is None:
+                os.environ.pop("CASHEL_PUBLIC_API_DOCS", None)
+            else:
+                os.environ["CASHEL_PUBLIC_API_DOCS"] = orig_public_docs
+            self._teardown(tmp, orig, orig_conn)
+
+    def test_public_api_docs_env_keeps_apispec_public(self):
+        client, tmp, orig, orig_conn = self._setup()
+        orig_public_docs = os.environ.get("CASHEL_PUBLIC_API_DOCS")
+        try:
+            us.create_user("publicspec", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+            os.environ["CASHEL_PUBLIC_API_DOCS"] = "yes"
+
+            resp = client.get("/apispec.json")
+
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.get_json()["info"]["title"], "Cashel API")
+        finally:
+            if orig_public_docs is None:
+                os.environ.pop("CASHEL_PUBLIC_API_DOCS", None)
+            else:
+                os.environ["CASHEL_PUBLIC_API_DOCS"] = orig_public_docs
+            self._teardown(tmp, orig, orig_conn)
+
+    def test_authenticated_users_can_access_private_api_docs_and_spec(self):
+        client, tmp, orig, orig_conn = self._setup()
+        try:
+            os.environ.pop("CASHEL_PUBLIC_API_DOCS", None)
+            us.create_user("privatedocs", "supersecretpass1", "admin")
+            from cashel.settings import save_settings, get_settings
+
+            save_settings({**get_settings(), "auth_enabled": True})
+            login_resp = client.post(
+                "/login",
+                data={
+                    "username": "privatedocs",
+                    "password": "supersecretpass1",
+                },
+                follow_redirects=False,
+            )
+            self.assertEqual(login_resp.status_code, 302)
+
+            docs_resp = client.get("/api/docs")
+            spec_resp = client.get("/apispec.json")
+
+            self.assertEqual(docs_resp.status_code, 200)
+            self.assertEqual(spec_resp.status_code, 200)
+            self.assertEqual(spec_resp.get_json()["info"]["title"], "Cashel API")
+        finally:
+            self._teardown(tmp, orig, orig_conn)
+
     def test_schedule_routes_create_update_run_delete(self):
         client, tmp, orig, orig_conn = self._setup()
         try:


### PR DESCRIPTION
## Summary

- Gate the Swagger UI and OpenAPI spec routes behind the existing authentication flow by default.
- Keep Swagger static assets public so authenticated docs rendering still works.
- Document the new deployment setting for intentionally public API docs.

## Behavior change

- `/api/docs` now requires authenticated access by default.
- `/apispec.json` now requires authenticated access by default.
- `/health` remains public and unchanged.
- Demo mode behavior is preserved through the existing demo auth bypass.
- Existing API v1 behavior is unchanged.

## New config setting and default

- `CASHEL_PUBLIC_API_DOCS=false` by default.
- Set `CASHEL_PUBLIC_API_DOCS=true` to keep `/api/docs` and `/apispec.json` public.
- Accepted truthy values are `true`, `1`, `yes`, and `on`.

## Tests added/updated

- Added coverage that `/health` remains public with auth enabled.
- Added coverage that `/api/docs` requires auth by default.
- Added coverage that `/apispec.json` requires auth by default.
- Added coverage that `CASHEL_PUBLIC_API_DOCS=true` keeps `/api/docs` public.
- Added coverage that truthy `CASHEL_PUBLIC_API_DOCS` keeps `/apispec.json` public.
- Added coverage that authenticated users can access private docs/spec routes.

## Validation results

- `python3 -m ruff format src/ tests/` completed; unrelated formatter-only churn was restored to keep this PR scoped.
- `python3 -m ruff check src/ tests/` passed.
- `python3 -m mypy src/cashel/ --ignore-missing-imports` passed.
- `python3 -m pytest tests/ -q` passed: 528 passed.
- `git diff --check` passed.

## Explicitly not included

- OIDC is not included.
- Scheduler locking is not included.
- API key deprecation is not included.
- License cleanup is not included.
