### PR TITLE
Document cashel.app and licensing retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Cashel** is a self-hosted firewall audit and remediation platform for network engineers, MSPs, and security teams. It audits uploaded firewall configurations and live SSH pulls, preserves evidence for each finding where the parser supports it, and produces remediation-oriented reports and exports that can be reviewed, repeated, and defended.
 
+**Website:** [cashel.app](https://cashel.app)
+
 The product direction is depth over breadth: trusted, evidence-backed, reproducible findings for the platforms engineers operate every day. Near-term work should prioritize Fortinet, Palo Alto Networks, and Cisco ASA/FTD correctness, SSO readiness, security hardening, operational clarity, and policy-as-code workflows before adding more vendors.
 
 **Demo:** [demo.cashel.app](https://demo.cashel.app)

--- a/docs/deprecated-commercial-listing.md
+++ b/docs/deprecated-commercial-listing.md
@@ -12,3 +12,13 @@ Cashel's current product direction is:
 - Compliance as data-driven evidence mapping, not an unlock assumption
 
 Do not publish this file as a product listing. If packaging is revisited, rewrite it from the product contract in [product-contract.md](product-contract.md) and avoid claims that imply equal maturity across every supported vendor.
+
+## Licensing Infrastructure
+
+Cashel is MIT-licensed and has no paid feature gating. The application does not
+read license keys, compliance checks run ungated, and the former Gumroad and
+Cloudflare license-issuance paths are decommissioned. Do not add activation,
+purchase, license-validation, or paid-feature checks back into the application.
+
+Any future commercial offering must be designed as a new system from a current
+product contract; it must not resurrect the retired license Worker.


### PR DESCRIPTION
## What changed

- adds the canonical `https://cashel.app` website link to the README
- adds a tracked prohibition against restoring the retired license infrastructure

## Why

Cashel is MIT-licensed, compliance runs ungated, and licensing must not be reintroduced by future work.

## Checks

- `git diff --check`
- repository scan for stale paid-license and legacy-domain references